### PR TITLE
Fix material selection recalculation for zero-cost materials and add regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2.5.2] - 2026-04-02
+### Fixed
+- Fixed calculator totals not recalculating when switching from a priced material to a zero-cost material.
+- Synced selected material values with spool weight/cost and single-material usage state to prevent stale filament totals.
+
+### Added
+- Added regression coverage for material-selection recalculation paths, including non-zero → zero and zero → non-zero transitions.
+
 ## [2.5.0] - 2026-03-03
 ### Added
 - Multi-material support for premium users, including picker and list components.
@@ -75,6 +83,7 @@
 ### Added
 - Added in-app update checker
 
+[2.5.2]: https://github.com/RemeJuan/threed_print_cost_calculator/compare/2.5.1...2.5.2
 [2.5.0]: https://github.com/RemeJuan/threed_print_cost_calculator/compare/2.4.0...2.5.0
 [2.4.1]: https://github.com/RemeJuan/threed_print_cost_calculator/compare/2.4.0...2.4.1
 [2.2.14]: https://github.com/RemeJuan/threed_print_cost_calculator/compare/2.2.13...2.2.14


### PR DESCRIPTION
### Motivation
- Fix a user-reported bug where switching from a priced material to a zero-cost material did not update calculator totals.
- Ensure selected-material changes reliably propagate spool weight/cost and single-material usage state to avoid stale filament totals.
- Add regression tests to prevent future regressions across non-zero → zero and zero → non-zero material transitions.

### Description
- Added `_costPerKgFromSpool` and `_syncedSingleMaterialUsage` helpers and a `selectMaterial` method to `lib/calculator/provider/calculator_notifier.dart` to compute `costPerKg` and sync selected material, spool weight/cost, and single-material usage state, and to trigger `submit()` after selection.
- Updated `updateSpoolWeight` and `updateSpoolCost` to synchronize single-material usage when there is only one usage, and unified spool cost parsing behavior.
- Relaxed the filament-cost presence check used to compute totals so a zero-cost material no longer leaves stale totals in place.
- Updated the material picker in `lib/calculator/view/material_select.dart` to use the new `selectMaterial` API.
- Added `test/calculator/provider/material_selection_recalculation_test.dart` with scenarios covering non-zero → non-zero, non-zero → zero, zero → non-zero transitions and a case where a zero-cost usage should override stale spool totals.
- Updated `CHANGELOG.md` with a `2.5.2` entry describing the fix, state-sync change, and the added regression coverage.

### Testing
- Added unit tests in `test/calculator/provider/material_selection_recalculation_test.dart` that exercise material selection transitions and stale-state override behavior, intended to run in CI or a developer environment.
- Attempted to run the tests locally with `fvm flutter test test/calculator/provider/material_selection_recalculation_test.dart`, but the run failed in this environment because `fvm` is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdee7945948332b37c44d510b95088)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Calculator totals now correctly recalculate when switching between priced and zero-cost materials.
  * Selected material values now stay synchronized with spool weight/cost and single-material usage to prevent stale filament totals.

* **Tests**
  * Added regression coverage for material-selection recalculation across zero↔non-zero transitions.

* **Documentation**
  * Added changelog entry for the new release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->