### PR TITLE
Add shared Pro promo visibility on calculator

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,30 +5,10 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Launch development",
+      "name": "Launch",
       "request": "launch",
       "type": "dart",
-      "program": "lib/main_development.dart",
-      "args": [
-        "--flavor",
-        "development",
-        "--target",
-        "lib/main_development.dart"
-      ]
+      "program": "lib/main.dart"
     },
-    {
-      "name": "Launch staging",
-      "request": "launch",
-      "type": "dart",
-      "program": "lib/main_staging.dart",
-      "args": ["--flavor", "staging", "--target", "lib/main_staging.dart"]
-    },
-    {
-      "name": "Launch production",
-      "request": "launch",
-      "type": "dart",
-      "program": "lib/main_production.dart",
-      "args": ["--flavor", "production", "--target", "lib/main_production.dart"]
-    }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,38 @@
-# Project commands (Flutter + FVM)
+# threed_print_cost_calculator
 
-Setup
+## Commands
+- Setup: `fvm flutter pub get`
+- Format: `fvm dart format .`
+- Analyze: `fvm flutter analyze`
+- Fast full test pass: `make flutter_test` (`fvm flutter test test --no-pub --test-randomize-ordering-seed random`)
+- Single test file: `fvm flutter test path/to_test.dart`
+- Coverage: `./scripts/coverage.sh` (`lcov` required; filters generated files plus `lib/bootstrap.dart` and `lib/firebase_options.dart`)
+- Codegen: `make flutter_generate`
+- Patrol release-gate E2E: `PATROL_FLUTTER_COMMAND="fvm flutter" patrol test --device emulator-5554 --no-uninstall`
+- Optional legacy integration sweep: `fvm flutter test integration_test`
 
-- fvm flutter pub get
+## Verify order
+- Default: `fvm flutter analyze` -> `make flutter_test`
+- If translations or generated code changed: run `make flutter_generate` before analyze/test
+- If app-shell or premium/history flows changed: run relevant `integration_test/` or Patrol journey
 
-Format
+## Architecture
+- Real app entrypoint: `lib/main.dart`. It initializes Firebase, App Check, Crashlytics, RevenueCat, Localizely, SharedPreferences, Sembast DB, then runs startup migrations before bootstrapping Riverpod overrides.
+- Root widget: `lib/app/app.dart`. Main shell: `lib/app/app_page.dart`.
+- Main feature boundaries: `lib/calculator/`, `lib/history/`, `lib/settings/`, `lib/database/`, `lib/purchases/`, `lib/shared/`.
+- `HistoryPage` exists only for premium users; `AppPage` dynamically removes that tab for free users.
 
-- fvm dart format .
+## Testing quirks
+- Widget tests should use `test/helpers/helpers.dart`; it installs mock SharedPreferences, in-memory Sembast, no-op analytics, and localization delegates.
+- Integration tests should use `integration_test/helpers/integration_test_harness.dart`; it seeds in-memory DB/prefs and fake purchases for free vs premium flows.
+- Startup/migration behavior has dedicated coverage in `test/main_migration_test.dart`; keep migration order stable when touching bootstrap/database startup.
 
-Analyze
+## Localisation
+- Never leave user-facing copy hardcoded when existing l10n system should be used.
+- ARB source: `lib/l10n/arb/`. Generated strings are consumed from `lib/generated/l10n.dart`.
+- Update all supported locales when adding/changing keys. Reuse existing wording patterns. Use placeholders, not string concatenation.
+- Do not localize developer-only strings such as logs, debug messages, test descriptions, identifiers, analytics keys, or API field names unless explicitly required.
 
-- fvm flutter analyze
-
-Test
-
-- fvm flutter test
-
-Optional codegen (if needed)
-
-- fvm flutter pub run build_runner build --delete-conflicting-outputs
+## Workflow notes
+- Prefer FVM-backed commands locally even if some CI jobs call plain `flutter`/`dart`.
+- `make bump_fix`, `make bump_feat`, `make bump_build` update app version; maintenance workflow uses `make bump_fix` after analyze/test pass.

--- a/integration_test/fixtures/integration_fixtures.dart
+++ b/integration_test/fixtures/integration_fixtures.dart
@@ -26,6 +26,8 @@ abstract final class IntegrationFixtures {
     color: 'Black',
     weight: '1000',
     archived: false,
+    originalWeight: 1000,
+    remainingWeight: 1000,
   );
 
   static const settings = GeneralSettingsModel(

--- a/lib/app/components/focus_safe_text_field.dart
+++ b/lib/app/components/focus_safe_text_field.dart
@@ -16,6 +16,7 @@ class FocusSafeTextField extends StatefulWidget {
   final bool? obscureText;
   final TextInputAction? textInputAction;
   final List<TextInputFormatter>? inputFormatters;
+  final String Function(String)? inputNormalizer;
 
   const FocusSafeTextField({
     super.key,
@@ -30,6 +31,7 @@ class FocusSafeTextField extends StatefulWidget {
     this.obscureText,
     this.textInputAction,
     this.inputFormatters,
+    this.inputNormalizer,
   });
 
   @override
@@ -133,7 +135,17 @@ class _FocusSafeTextFieldState extends State<FocusSafeTextField> {
     return TextFormField(
       controller: widget.controller,
       focusNode: _node,
-      onChanged: widget.onChanged,
+      onChanged: (value) {
+        final normalized = widget.inputNormalizer?.call(value) ?? value;
+        if (normalized != value) {
+          widget.controller.value = TextEditingValue(
+            text: normalized,
+            selection: TextSelection.collapsed(offset: normalized.length),
+            composing: TextRange.empty,
+          );
+        }
+        widget.onChanged?.call(normalized);
+      },
       validator: widget.validator,
       autovalidateMode: widget.autovalidateMode,
       keyboardType: widget.keyboardType,

--- a/lib/calculator/helpers/calculator_helpers.dart
+++ b/lib/calculator/helpers/calculator_helpers.dart
@@ -3,6 +3,9 @@ import 'package:riverpod/riverpod.dart';
 import 'package:threed_print_cost_calculator/database/repositories/calculator_preferences_repository.dart';
 import 'package:threed_print_cost_calculator/database/repositories/history_repository.dart';
 import 'package:threed_print_cost_calculator/calculator/model/material_usage_input.dart';
+import 'package:threed_print_cost_calculator/core/logging/app_logger.dart';
+import 'package:threed_print_cost_calculator/database/services/material_stock_service.dart';
+import 'package:threed_print_cost_calculator/generated/l10n.dart';
 import 'package:threed_print_cost_calculator/history/model/history_model.dart';
 
 final calculatorHelpersProvider = Provider<CalculatorHelpers>(
@@ -65,9 +68,24 @@ class CalculatorHelpers {
   Future<void> savePrint(HistoryModel value) async {
     try {
       await ref.read(historyRepositoryProvider).saveHistory(value);
-      BotToast.showText(text: 'Print saved');
     } catch (e) {
-      BotToast.showText(text: 'Error saving print');
+      BotToast.showText(text: S.current.savePrintErrorMessage);
+      return;
     }
+
+    try {
+      await ref.read(materialStockServiceProvider).deductForSavedHistory(value);
+    } catch (error, stackTrace) {
+      ref
+          .read(appLoggerProvider)
+          .warn(
+            AppLogCategory.db,
+            'History saved but material stock deduction failed',
+            error: error,
+            stackTrace: stackTrace,
+          );
+    }
+
+    BotToast.showText(text: S.current.savePrintSuccessMessage);
   }
 }

--- a/lib/calculator/view/components/adjustments_section.dart
+++ b/lib/calculator/view/components/adjustments_section.dart
@@ -6,6 +6,7 @@ import 'package:threed_print_cost_calculator/app/components/focus_safe_text_fiel
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:threed_print_cost_calculator/purchases/premium_state_notifier.dart';
 import 'package:threed_print_cost_calculator/shared/utils/number_parsing.dart';
+import 'package:threed_print_cost_calculator/shared/utils/text_input_normalizers.dart';
 
 class AdjustmentsSection extends HookConsumerWidget {
   const AdjustmentsSection({super.key});
@@ -43,6 +44,7 @@ class AdjustmentsSection extends HookConsumerWidget {
             externalText: state.labourRate.value?.toString() ?? '',
             focusNode: labourRateFocus,
             keyboardType: TextInputType.number,
+            inputNormalizer: normalizeLeadingZeroNumericInput,
             decoration: InputDecoration(labelText: l10n.labourRateLabel),
             onChanged: (value) async {
               notifier.setLabourRate(parseLocalizedNum(value));
@@ -60,6 +62,7 @@ class AdjustmentsSection extends HookConsumerWidget {
             externalText: state.labourTime.value?.toString() ?? '',
             focusNode: labourTimeFocus,
             keyboardType: TextInputType.number,
+            inputNormalizer: normalizeLeadingZeroNumericInput,
             decoration: InputDecoration(labelText: l10n.labourTimeLabel),
             onChanged: (value) async {
               notifier

--- a/lib/calculator/view/components/duration_dialog.dart
+++ b/lib/calculator/view/components/duration_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:threed_print_cost_calculator/generated/l10n.dart';
+import 'package:threed_print_cost_calculator/shared/utils/text_input_normalizers.dart';
 
 /// A dialog that lets the user input hours (free numeric) and minutes (0-59).
 /// Returns a `Map<String,int>` via Navigator.pop: {'hours': hours, 'minutes': minutes}.
@@ -25,6 +26,20 @@ class _DurationDialogState extends State<DurationDialog> {
   late final TextEditingController _minutesController;
   late final FocusNode _hoursFocus;
   late final FocusNode _minutesFocus;
+
+  void _normalizeController(TextEditingController controller) {
+    final normalized = normalizeLeadingZeroNumericInput(
+      controller.text,
+      allowDecimal: false,
+    );
+    if (normalized == controller.text) return;
+
+    controller.value = TextEditingValue(
+      text: normalized,
+      selection: TextSelection.collapsed(offset: normalized.length),
+      composing: TextRange.empty,
+    );
+  }
 
   @override
   void initState() {
@@ -80,29 +95,9 @@ class _DurationDialogState extends State<DurationDialog> {
                   inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                   decoration: InputDecoration(
                     labelText: widget.l10n.hoursLabel,
-                    hintText: 'e.g. 123',
+                    hintText: widget.l10n.numberExampleHint,
                   ),
-                  onChanged: (v) {
-                    // Normalize leading zeros: when user types over an initial '0',
-                    // we want '1' not '01'. If the text has more than 1 char and
-                    // starts with '0', strip leading zeros (but keep a single '0').
-                    String text = _hoursController.text;
-                    if (text.length > 1 && text.startsWith('0')) {
-                      final normalized = text.replaceFirst(RegExp(r'^0+'), '');
-                      final newText = normalized.isEmpty ? '0' : normalized;
-                      if (newText != text) {
-                        // Update controller text once; this will trigger onChanged again,
-                        // but the normalized text won't need further normalization.
-                        _hoursController.text = newText;
-                      }
-                    }
-
-                    // Ensure the caret is at the end after any normalization.
-                    final len = _hoursController.text.length;
-                    _hoursController.selection = TextSelection.fromPosition(
-                      TextPosition(offset: len),
-                    );
-                  },
+                  onChanged: (_) => _normalizeController(_hoursController),
                 ),
               ),
               const SizedBox(width: 12),
@@ -115,6 +110,7 @@ class _DurationDialogState extends State<DurationDialog> {
                   focusNode: _minutesFocus,
                   keyboardType: TextInputType.number,
                   inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                  onChanged: (_) => _normalizeController(_minutesController),
                   decoration: InputDecoration(
                     labelText: widget.l10n.minutesLabel,
                   ),

--- a/lib/calculator/view/components/materials_selection/material_picker.dart
+++ b/lib/calculator/view/components/materials_selection/material_picker.dart
@@ -157,7 +157,7 @@ class MaterialPicker extends HookConsumerWidget {
       error: (error, stackTrace) => Center(
         child: Padding(
           padding: const EdgeInsets.all(16),
-          child: Text('Failed to load materials: $error'),
+          child: Text(l10n.materialsLoadError(error.toString())),
         ),
       ),
     );

--- a/lib/calculator/view/components/materials_selection/material_row.dart
+++ b/lib/calculator/view/components/materials_selection/material_row.dart
@@ -115,6 +115,8 @@ class _MaterialRowState extends State<MaterialRow> {
             focusNode: _weightFocusNode,
             externalText: _weightText,
             keyboardType: TextInputType.number,
+            inputNormalizer: (value) =>
+                normalizeLeadingZeroNumericInput(value, allowDecimal: false),
             decoration: InputDecoration(suffixText: l10n.gramsSuffix),
             onChanged: (value) {
               final parsedVal = parseLocalizedInt(value);

--- a/lib/calculator/view/components/materials_selection/material_row.dart
+++ b/lib/calculator/view/components/materials_selection/material_row.dart
@@ -6,6 +6,7 @@ import 'package:threed_print_cost_calculator/generated/l10n.dart';
 import 'package:threed_print_cost_calculator/app/components/focus_safe_text_field.dart';
 import 'package:threed_print_cost_calculator/shared/constants.dart';
 import 'package:threed_print_cost_calculator/shared/utils/number_parsing.dart';
+import 'package:threed_print_cost_calculator/shared/utils/text_input_normalizers.dart';
 
 /// Single material row used inside the materials list.
 ///
@@ -58,8 +59,15 @@ class _MaterialRowState extends State<MaterialRow> {
   Widget build(BuildContext context) {
     final l10n = S.of(context);
     final colorString = widget.material?.color ?? '';
+    final remainingWeight = widget.material?.remainingWeight ?? 0;
     final id = widget.usage.materialId.trim();
     final rowKey = id.isNotEmpty ? id : '__row_${widget.index}';
+
+    String formatWeight(num value) {
+      return value % 1 == 0
+          ? value.toStringAsFixed(0)
+          : value.toStringAsFixed(1);
+    }
 
     final isMaterialUnassigned =
         widget.usage.materialName.isEmpty ||
@@ -77,18 +85,32 @@ class _MaterialRowState extends State<MaterialRow> {
             child: Row(
               children: [
                 Flexible(
-                  child: Text(
-                    key: ValueKey<String>(
-                      'calculator.materials.item.${widget.index}.name',
-                    ),
-                    isMaterialUnassigned
-                        ? l10n.selectMaterialHint
-                        : widget.usage.materialName,
-                    style: isMaterialUnassigned
-                        ? Theme.of(context).textTheme.bodyMedium?.copyWith(
-                            color: Theme.of(context).hintColor,
-                          )
-                        : Theme.of(context).textTheme.bodyMedium,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        key: ValueKey<String>(
+                          'calculator.materials.item.${widget.index}.name',
+                        ),
+                        isMaterialUnassigned
+                            ? l10n.selectMaterialHint
+                            : widget.usage.materialName,
+                        style: isMaterialUnassigned
+                            ? Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                color: Theme.of(context).hintColor,
+                              )
+                            : Theme.of(context).textTheme.bodyMedium,
+                      ),
+                      if (widget.material?.autoDeductEnabled == true)
+                        Text(
+                          key: ValueKey<String>(
+                            'calculator.materials.item.${widget.index}.remaining',
+                          ),
+                          '${l10n.remainingLabel} ${formatWeight(remainingWeight)}${l10n.gramsSuffix}',
+                          style: Theme.of(context).textTheme.bodySmall,
+                        ),
+                    ],
                   ),
                 ),
                 if (colorString.isNotEmpty) ...[

--- a/lib/calculator/view/components/materials_selection/materials_section_free.dart
+++ b/lib/calculator/view/components/materials_selection/materials_section_free.dart
@@ -5,6 +5,7 @@ import 'package:threed_print_cost_calculator/app/components/focus_safe_text_fiel
 import 'package:threed_print_cost_calculator/calculator/provider/calculator_notifier.dart';
 import 'package:threed_print_cost_calculator/generated/l10n.dart';
 import 'package:threed_print_cost_calculator/shared/utils/number_parsing.dart';
+import 'package:threed_print_cost_calculator/shared/utils/text_input_normalizers.dart';
 
 class MaterialsSectionFree extends HookConsumerWidget {
   const MaterialsSectionFree({super.key});
@@ -43,6 +44,7 @@ class MaterialsSectionFree extends HookConsumerWidget {
                 externalText: state.spoolWeight.value?.toString() ?? '',
                 focusNode: spoolWeightFocus,
                 keyboardType: TextInputType.number,
+                inputNormalizer: normalizeLeadingZeroNumericInput,
                 decoration: InputDecoration(
                   labelText: l10n.spoolWeightLabel,
                   suffixText: l10n.gramsSuffix,
@@ -66,6 +68,7 @@ class MaterialsSectionFree extends HookConsumerWidget {
                 keyboardType: const TextInputType.numberWithOptions(
                   decimal: true,
                 ),
+                inputNormalizer: normalizeLeadingZeroNumericInput,
                 decoration: InputDecoration(labelText: l10n.spoolCostLabel),
                 onChanged: (value) {
                   notifier
@@ -82,6 +85,7 @@ class MaterialsSectionFree extends HookConsumerWidget {
           externalText: state.printWeight.value?.toString() ?? '',
           focusNode: printWeightFocus,
           keyboardType: TextInputType.number,
+          inputNormalizer: normalizeLeadingZeroNumericInput,
           decoration: InputDecoration(labelText: l10n.printWeightLabel),
           onChanged: (value) {
             notifier

--- a/lib/calculator/view/components/rates_section.dart
+++ b/lib/calculator/view/components/rates_section.dart
@@ -6,6 +6,7 @@ import 'package:threed_print_cost_calculator/generated/l10n.dart';
 import 'package:threed_print_cost_calculator/purchases/premium_state_notifier.dart';
 import 'package:threed_print_cost_calculator/app/components/focus_safe_text_field.dart';
 import 'package:threed_print_cost_calculator/shared/utils/number_parsing.dart';
+import 'package:threed_print_cost_calculator/shared/utils/text_input_normalizers.dart';
 
 class RatesSection extends HookConsumerWidget {
   const RatesSection({super.key});
@@ -41,6 +42,7 @@ class RatesSection extends HookConsumerWidget {
             externalText: state.wearAndTear.value?.toString() ?? '',
             focusNode: wearFocus,
             keyboardType: TextInputType.number,
+            inputNormalizer: normalizeLeadingZeroNumericInput,
             decoration: InputDecoration(labelText: l10n.wearAndTearLabel),
             onChanged: (value) async {
               notifier.setWearAndTear(parseLocalizedNum(value));
@@ -56,6 +58,7 @@ class RatesSection extends HookConsumerWidget {
             externalText: state.failureRisk.value?.toString() ?? '',
             focusNode: failureFocus,
             keyboardType: TextInputType.number,
+            inputNormalizer: normalizeLeadingZeroNumericInput,
             decoration: InputDecoration(labelText: l10n.failureRiskLabel),
             onChanged: (value) async {
               notifier.setFailureRisk(parseLocalizedNum(value));

--- a/lib/calculator/view/material_select.dart
+++ b/lib/calculator/view/material_select.dart
@@ -16,6 +16,12 @@ class MaterialSelect extends HookConsumerWidget {
     final generalSettings = useState(GeneralSettingsModel.initial());
     final l10n = S.of(context);
 
+    String formatWeight(num value) {
+      return value % 1 == 0
+          ? value.toStringAsFixed(0)
+          : value.toStringAsFixed(1);
+    }
+
     Future<void> getSettings() async {
       generalSettings.value = await ref
           .read(settingsRepositoryProvider)
@@ -51,6 +57,28 @@ class MaterialSelect extends HookConsumerWidget {
             alignment: AlignmentDirectional.centerStart,
             isExpanded: true,
             value: selectedValue,
+            selectedItemBuilder: (_) {
+              return data.map((e) {
+                return Align(
+                  alignment: Alignment.centerLeft,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(e.name),
+                      if (e.autoDeductEnabled)
+                        Text(
+                          '${l10n.remainingLabel} ${formatWeight(e.remainingWeight)}${l10n.gramsSuffix}',
+                          key: ValueKey<String>(
+                            'calculator.materialSelect.remaining.${e.id}',
+                          ),
+                          style: Theme.of(context).textTheme.bodySmall,
+                        ),
+                    ],
+                  ),
+                );
+              }).toList();
+            },
             items: data.map((e) {
               return DropdownMenuItem(
                 value: e.id,

--- a/lib/database/database_helpers.dart
+++ b/lib/database/database_helpers.dart
@@ -4,6 +4,7 @@ import 'package:sembast/sembast.dart';
 
 // ignore: implementation_imports
 import 'package:sembast/src/type.dart';
+import 'package:threed_print_cost_calculator/generated/l10n.dart';
 import 'package:threed_print_cost_calculator/shared/providers/app_providers.dart';
 import 'package:threed_print_cost_calculator/settings/model/general_settings_model.dart';
 import 'package:threed_print_cost_calculator/history/index/history_search_index.dart';
@@ -75,7 +76,7 @@ class DataBaseHelpers {
       ref.read(historyPagedProvider.notifier).markStale();
       return key;
     } catch (e) {
-      BotToast.showText(text: 'Error saving print');
+      BotToast.showText(text: S.current.savePrintErrorMessage);
       rethrow;
     }
   }
@@ -121,7 +122,7 @@ class DataBaseHelpers {
         await store.record(key).update(db, data);
       }
     } catch (e) {
-      BotToast.showText(text: 'Error saving print');
+      BotToast.showText(text: S.current.savePrintErrorMessage);
     }
   }
 
@@ -202,7 +203,7 @@ class DataBaseHelpers {
     try {
       return await store.record(key).getSnapshot(db);
     } catch (e) {
-      BotToast.showText(text: 'Error saving print');
+      BotToast.showText(text: S.current.savePrintErrorMessage);
     }
     return null;
   }

--- a/lib/database/services/material_stock_service.dart
+++ b/lib/database/services/material_stock_service.dart
@@ -1,0 +1,71 @@
+import 'dart:math' as math;
+
+import 'package:riverpod/riverpod.dart';
+import 'package:sembast/sembast.dart';
+import 'package:threed_print_cost_calculator/calculator/model/material_usage_input.dart';
+import 'package:threed_print_cost_calculator/history/model/history_model.dart';
+import 'package:threed_print_cost_calculator/settings/model/material_model.dart';
+import 'package:threed_print_cost_calculator/shared/providers/app_providers.dart';
+
+final materialStockServiceProvider = Provider<MaterialStockService>(
+  MaterialStockService.new,
+);
+
+class MaterialStockService {
+  MaterialStockService(this.ref);
+
+  final Ref ref;
+
+  Database get _db => ref.read(databaseProvider);
+
+  StoreRef<String, Map<String, dynamic>> get _store =>
+      stringMapStoreFactory.store('materials');
+
+  Future<void> deductForSavedHistory(HistoryModel history) async {
+    final totalsByMaterialId = <String, int>{};
+
+    for (final usageMap in history.materialUsages) {
+      final usage = MaterialUsageInput.fromMap(usageMap);
+      final materialId = usage.materialId.trim();
+
+      if (materialId.isEmpty || usage.weightGrams <= 0) {
+        continue;
+      }
+
+      totalsByMaterialId.update(
+        materialId,
+        (current) => current + usage.weightGrams,
+        ifAbsent: () => usage.weightGrams,
+      );
+    }
+
+    if (totalsByMaterialId.isEmpty) return;
+
+    await _db.transaction((txn) async {
+      for (final entry in totalsByMaterialId.entries) {
+        final snapshot = await _store.record(entry.key).getSnapshot(txn);
+        if (snapshot == null) {
+          continue;
+        }
+
+        final material = MaterialModel.fromMap(snapshot.value, snapshot.key);
+        if (!material.autoDeductEnabled) {
+          continue;
+        }
+
+        await _store
+            .record(entry.key)
+            .put(
+              txn,
+              material
+                  .copyWith(
+                    remainingWeight: math
+                        .max(0, material.remainingWeight - entry.value)
+                        .toDouble(),
+                  )
+                  .toMap(),
+            );
+      }
+    });
+  }
+}

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -27,6 +27,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m2(version) => "Version ${version}";
 
+  static String m3(error) => "Fehler beim Laden der Materialien: ${error}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
     "addAtLeastOneMaterial": MessageLookupByLibrary.simpleMessage(
@@ -93,6 +95,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Materialaufschlüsselung",
     ),
     "materialFallback": MessageLookupByLibrary.simpleMessage("Materialtyp"),
+    "materialsLoadError": m3,
     "materialNameLabel": MessageLookupByLibrary.simpleMessage("Materialname *"),
     "materialNone": MessageLookupByLibrary.simpleMessage("Keine"),
     "materialWeightExplanation": MessageLookupByLibrary.simpleMessage(
@@ -104,6 +107,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "needHelpTitle": MessageLookupByLibrary.simpleMessage(
       "Brauchen Sie Hilfe?",
     ),
+    "numberExampleHint": MessageLookupByLibrary.simpleMessage("z. B. 123"),
     "offeringsError": MessageLookupByLibrary.simpleMessage("Fehler: "),
     "premiumHeader": MessageLookupByLibrary.simpleMessage(
       "Nur Premium-Benutzer:",
@@ -117,12 +121,17 @@ class MessageLookup extends MessageLookupByLibrary {
     "privacyPolicyLink": MessageLookupByLibrary.simpleMessage(
       "Datenschutzrichtlinie",
     ),
+    "remainingFilamentLabel": MessageLookupByLibrary.simpleMessage(
+      "Verbleibendes Filament",
+    ),
+    "remainingLabel": MessageLookupByLibrary.simpleMessage("Verbleibend:"),
     "purchaseError": MessageLookupByLibrary.simpleMessage(
       "Beim Verarbeiten Ihres Kaufs ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut.",
     ),
     "restorePurchases": MessageLookupByLibrary.simpleMessage(
       "Käufe wiederherstellen",
     ),
+    "retryButton": MessageLookupByLibrary.simpleMessage("Erneut versuchen"),
     "resultElectricityPrefix": MessageLookupByLibrary.simpleMessage(
       "Gesamtkosten für Strom:",
     ),
@@ -134,6 +143,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "riskTotalPrefix": MessageLookupByLibrary.simpleMessage("Risikokosten:"),
     "saveButton": MessageLookupByLibrary.simpleMessage("Speichern"),
     "savePrintButton": MessageLookupByLibrary.simpleMessage("Druck speichern"),
+    "savePrintErrorMessage": MessageLookupByLibrary.simpleMessage(
+      "Fehler beim Speichern des Drucks",
+    ),
+    "savePrintSuccessMessage": MessageLookupByLibrary.simpleMessage(
+      "Druck gespeichert",
+    ),
     "searchMaterialsHint": MessageLookupByLibrary.simpleMessage(
       "Materialien suchen",
     ),
@@ -158,6 +173,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "supportEmail": MessageLookupByLibrary.simpleMessage("google@remej.dev"),
     "supportEmailPrefix": MessageLookupByLibrary.simpleMessage(
       "Bei Problemen schreiben Sie mir bitte an ",
+    ),
+    "trackRemainingFilamentLabel": MessageLookupByLibrary.simpleMessage(
+      "Verbleibendes Filament verfolgen",
     ),
     "supportIdCopied": MessageLookupByLibrary.simpleMessage(
       "Support-ID kopiert",

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -27,6 +27,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m2(version) => "Version ${version}";
 
+  static String m3(error) => "Failed to load materials: ${error}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
     "addAtLeastOneMaterial": MessageLookupByLibrary.simpleMessage(
@@ -87,6 +89,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Material breakdown",
     ),
     "materialFallback": MessageLookupByLibrary.simpleMessage("Material"),
+    "materialsLoadError": m3,
     "materialNameLabel": MessageLookupByLibrary.simpleMessage("Name *"),
     "materialNone": MessageLookupByLibrary.simpleMessage("None"),
     "materialWeightExplanation": MessageLookupByLibrary.simpleMessage(
@@ -96,6 +99,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "materialsHeader": MessageLookupByLibrary.simpleMessage("Materials"),
     "minutesLabel": MessageLookupByLibrary.simpleMessage("Minutes"),
     "needHelpTitle": MessageLookupByLibrary.simpleMessage("Need Help?"),
+    "numberExampleHint": MessageLookupByLibrary.simpleMessage("e.g. 123"),
     "offeringsError": MessageLookupByLibrary.simpleMessage("Error: "),
     "premiumHeader": MessageLookupByLibrary.simpleMessage(
       "Premium users only:",
@@ -105,12 +109,17 @@ class MessageLookup extends MessageLookupByLibrary {
     "printerNameLabel": MessageLookupByLibrary.simpleMessage("Name *"),
     "printersHeader": MessageLookupByLibrary.simpleMessage("Printers"),
     "privacyPolicyLink": MessageLookupByLibrary.simpleMessage("Privacy Policy"),
+    "remainingFilamentLabel": MessageLookupByLibrary.simpleMessage(
+      "Remaining filament",
+    ),
+    "remainingLabel": MessageLookupByLibrary.simpleMessage("Remaining:"),
     "purchaseError": MessageLookupByLibrary.simpleMessage(
       "There was an error processing your purchase. Please try again later.",
     ),
     "restorePurchases": MessageLookupByLibrary.simpleMessage(
       "Restore Purchases",
     ),
+    "retryButton": MessageLookupByLibrary.simpleMessage("Retry"),
     "resultElectricityPrefix": MessageLookupByLibrary.simpleMessage(
       "Electricity",
     ),
@@ -120,6 +129,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "riskTotalPrefix": MessageLookupByLibrary.simpleMessage("Risk"),
     "saveButton": MessageLookupByLibrary.simpleMessage("Save"),
     "savePrintButton": MessageLookupByLibrary.simpleMessage("Save Print"),
+    "savePrintErrorMessage": MessageLookupByLibrary.simpleMessage(
+      "Error saving print",
+    ),
+    "savePrintSuccessMessage": MessageLookupByLibrary.simpleMessage(
+      "Print saved",
+    ),
     "searchMaterialsHint": MessageLookupByLibrary.simpleMessage(
       "Search materials",
     ),
@@ -136,6 +151,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "supportEmail": MessageLookupByLibrary.simpleMessage("google@remej.dev"),
     "supportEmailPrefix": MessageLookupByLibrary.simpleMessage(
       "For any issues, please mail me at ",
+    ),
+    "trackRemainingFilamentLabel": MessageLookupByLibrary.simpleMessage(
+      "Track remaining filament",
     ),
     "supportIdCopied": MessageLookupByLibrary.simpleMessage(
       "Support ID Copied",

--- a/lib/generated/intl/messages_es.dart
+++ b/lib/generated/intl/messages_es.dart
@@ -27,6 +27,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m2(version) => "Versión ${version}";
 
+  static String m3(error) => "Error al cargar los materiales: ${error}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
     "addAtLeastOneMaterial": MessageLookupByLibrary.simpleMessage(
@@ -99,6 +101,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "materialFallback": MessageLookupByLibrary.simpleMessage(
       "Material genérico",
     ),
+    "materialsLoadError": m3,
     "materialNameLabel": MessageLookupByLibrary.simpleMessage(
       "Nombre del material *",
     ),
@@ -110,6 +113,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "materialsHeader": MessageLookupByLibrary.simpleMessage("Materiales"),
     "minutesLabel": MessageLookupByLibrary.simpleMessage("Minutos"),
     "needHelpTitle": MessageLookupByLibrary.simpleMessage("¿Necesitas ayuda?"),
+    "numberExampleHint": MessageLookupByLibrary.simpleMessage("p. ej. 123"),
     "offeringsError": MessageLookupByLibrary.simpleMessage(
       "Error de ofertas: ",
     ),
@@ -127,12 +131,17 @@ class MessageLookup extends MessageLookupByLibrary {
     "privacyPolicyLink": MessageLookupByLibrary.simpleMessage(
       "Política de privacidad",
     ),
+    "remainingFilamentLabel": MessageLookupByLibrary.simpleMessage(
+      "Filamento restante",
+    ),
+    "remainingLabel": MessageLookupByLibrary.simpleMessage("Restante:"),
     "purchaseError": MessageLookupByLibrary.simpleMessage(
       "Hubo un error al procesar tu compra. Inténtalo de nuevo más tarde.",
     ),
     "restorePurchases": MessageLookupByLibrary.simpleMessage(
       "Restaurar compras",
     ),
+    "retryButton": MessageLookupByLibrary.simpleMessage("Reintentar"),
     "resultElectricityPrefix": MessageLookupByLibrary.simpleMessage(
       "Costo total de Electricidad: ",
     ),
@@ -147,6 +156,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "saveButton": MessageLookupByLibrary.simpleMessage("Guardar"),
     "savePrintButton": MessageLookupByLibrary.simpleMessage(
       "Guardar impresión",
+    ),
+    "savePrintErrorMessage": MessageLookupByLibrary.simpleMessage(
+      "Error al guardar la impresión",
+    ),
+    "savePrintSuccessMessage": MessageLookupByLibrary.simpleMessage(
+      "Impresión guardada",
     ),
     "searchMaterialsHint": MessageLookupByLibrary.simpleMessage(
       "Buscar materiales",
@@ -170,6 +185,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "supportEmail": MessageLookupByLibrary.simpleMessage("google@remej.dev"),
     "supportEmailPrefix": MessageLookupByLibrary.simpleMessage(
       "Si tienes algún problema, escríbeme a ",
+    ),
+    "trackRemainingFilamentLabel": MessageLookupByLibrary.simpleMessage(
+      "Hacer seguimiento del filamento restante",
     ),
     "supportIdCopied": MessageLookupByLibrary.simpleMessage(
       "ID de soporte copiado",

--- a/lib/generated/intl/messages_fr.dart
+++ b/lib/generated/intl/messages_fr.dart
@@ -27,6 +27,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m2(version) => "Version ${version}";
 
+  static String m3(error) => "Échec du chargement des matériaux : ${error}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
     "addAtLeastOneMaterial": MessageLookupByLibrary.simpleMessage(
@@ -103,6 +105,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Répartition des matériaux",
     ),
     "materialFallback": MessageLookupByLibrary.simpleMessage("Matériau"),
+    "materialsLoadError": m3,
     "materialNameLabel": MessageLookupByLibrary.simpleMessage(
       "Nom du matériau *",
     ),
@@ -114,6 +117,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "materialsHeader": MessageLookupByLibrary.simpleMessage("Matériaux"),
     "minutesLabel": MessageLookupByLibrary.simpleMessage("Min."),
     "needHelpTitle": MessageLookupByLibrary.simpleMessage("Besoin d\'aide ?"),
+    "numberExampleHint": MessageLookupByLibrary.simpleMessage("ex. 123"),
     "offeringsError": MessageLookupByLibrary.simpleMessage("Erreur : "),
     "premiumHeader": MessageLookupByLibrary.simpleMessage(
       "Utilisateurs Premium uniquement :",
@@ -129,12 +133,17 @@ class MessageLookup extends MessageLookupByLibrary {
     "privacyPolicyLink": MessageLookupByLibrary.simpleMessage(
       "Politique de confidentialité",
     ),
+    "remainingFilamentLabel": MessageLookupByLibrary.simpleMessage(
+      "Filament restant",
+    ),
+    "remainingLabel": MessageLookupByLibrary.simpleMessage("Restant :"),
     "purchaseError": MessageLookupByLibrary.simpleMessage(
       "Une erreur est survenue lors du traitement de votre achat. Veuillez réessayer plus tard.",
     ),
     "restorePurchases": MessageLookupByLibrary.simpleMessage(
       "Restaurer les achats",
     ),
+    "retryButton": MessageLookupByLibrary.simpleMessage("Réessayer"),
     "resultElectricityPrefix": MessageLookupByLibrary.simpleMessage(
       "Coût total de l\'électricité : ",
     ),
@@ -149,6 +158,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "saveButton": MessageLookupByLibrary.simpleMessage("Enregistrer"),
     "savePrintButton": MessageLookupByLibrary.simpleMessage(
       "Enregistrer l\'impression",
+    ),
+    "savePrintErrorMessage": MessageLookupByLibrary.simpleMessage(
+      "Erreur lors de l\'enregistrement de l\'impression",
+    ),
+    "savePrintSuccessMessage": MessageLookupByLibrary.simpleMessage(
+      "Impression enregistrée",
     ),
     "searchMaterialsHint": MessageLookupByLibrary.simpleMessage(
       "Rechercher des matériaux",
@@ -172,6 +187,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "supportEmail": MessageLookupByLibrary.simpleMessage("google@remej.dev"),
     "supportEmailPrefix": MessageLookupByLibrary.simpleMessage(
       "En cas de problème, envoyez-moi un e-mail à ",
+    ),
+    "trackRemainingFilamentLabel": MessageLookupByLibrary.simpleMessage(
+      "Suivre le filament restant",
     ),
     "supportIdCopied": MessageLookupByLibrary.simpleMessage(
       "ID de support copié",

--- a/lib/generated/intl/messages_id.dart
+++ b/lib/generated/intl/messages_id.dart
@@ -26,6 +26,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m2(version) => "Versi ${version}";
 
+  static String m3(error) => "Gagal memuat material: ${error}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
     "addAtLeastOneMaterial": MessageLookupByLibrary.simpleMessage(
@@ -92,6 +94,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Rincian bahan",
     ),
     "materialFallback": MessageLookupByLibrary.simpleMessage("Bahan"),
+    "materialsLoadError": m3,
     "materialNameLabel": MessageLookupByLibrary.simpleMessage("Nama bahan *"),
     "materialNone": MessageLookupByLibrary.simpleMessage("Tidak ada"),
     "materialWeightExplanation": MessageLookupByLibrary.simpleMessage(
@@ -101,6 +104,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "materialsHeader": MessageLookupByLibrary.simpleMessage("Bahan"),
     "minutesLabel": MessageLookupByLibrary.simpleMessage("Menit"),
     "needHelpTitle": MessageLookupByLibrary.simpleMessage("Butuh bantuan?"),
+    "numberExampleHint": MessageLookupByLibrary.simpleMessage("mis. 123"),
     "offeringsError": MessageLookupByLibrary.simpleMessage("Kesalahan: "),
     "premiumHeader": MessageLookupByLibrary.simpleMessage(
       "Khusus pengguna premium:",
@@ -112,12 +116,17 @@ class MessageLookup extends MessageLookupByLibrary {
     "privacyPolicyLink": MessageLookupByLibrary.simpleMessage(
       "Kebijakan Privasi",
     ),
+    "remainingFilamentLabel": MessageLookupByLibrary.simpleMessage(
+      "Sisa filamen",
+    ),
+    "remainingLabel": MessageLookupByLibrary.simpleMessage("Sisa:"),
     "purchaseError": MessageLookupByLibrary.simpleMessage(
       "Terjadi kesalahan saat memproses pembelian Anda. Silakan coba lagi nanti.",
     ),
     "restorePurchases": MessageLookupByLibrary.simpleMessage(
       "Pulihkan pembelian",
     ),
+    "retryButton": MessageLookupByLibrary.simpleMessage("Coba lagi"),
     "resultElectricityPrefix": MessageLookupByLibrary.simpleMessage(
       "Total biaya Listrik: ",
     ),
@@ -129,6 +138,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "riskTotalPrefix": MessageLookupByLibrary.simpleMessage("Biaya risiko: "),
     "saveButton": MessageLookupByLibrary.simpleMessage("Simpan"),
     "savePrintButton": MessageLookupByLibrary.simpleMessage("Simpan cetakan"),
+    "savePrintErrorMessage": MessageLookupByLibrary.simpleMessage(
+      "Gagal menyimpan hasil cetak",
+    ),
+    "savePrintSuccessMessage": MessageLookupByLibrary.simpleMessage(
+      "Hasil cetak disimpan",
+    ),
     "searchMaterialsHint": MessageLookupByLibrary.simpleMessage("Cari bahan"),
     "selectMaterialHint": MessageLookupByLibrary.simpleMessage(
       "Kustom (belum disimpan)",
@@ -145,6 +160,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "supportEmail": MessageLookupByLibrary.simpleMessage("google@remej.dev"),
     "supportEmailPrefix": MessageLookupByLibrary.simpleMessage(
       "Jika ada masalah, silakan email saya di ",
+    ),
+    "trackRemainingFilamentLabel": MessageLookupByLibrary.simpleMessage(
+      "Lacak sisa filamen",
     ),
     "supportIdCopied": MessageLookupByLibrary.simpleMessage(
       "ID Dukungan disalin",

--- a/lib/generated/intl/messages_it.dart
+++ b/lib/generated/intl/messages_it.dart
@@ -27,6 +27,9 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m2(version) => "Versione ${version}";
 
+  static String m3(error) =>
+      "Errore durante il caricamento dei materiali: ${error}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
     "addAtLeastOneMaterial": MessageLookupByLibrary.simpleMessage(
@@ -93,6 +96,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Dettaglio materiali",
     ),
     "materialFallback": MessageLookupByLibrary.simpleMessage("Materiale"),
+    "materialsLoadError": m3,
     "materialNameLabel": MessageLookupByLibrary.simpleMessage(
       "Nome materiale *",
     ),
@@ -106,6 +110,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "needHelpTitle": MessageLookupByLibrary.simpleMessage(
       "Hai bisogno di aiuto?",
     ),
+    "numberExampleHint": MessageLookupByLibrary.simpleMessage("es. 123"),
     "offeringsError": MessageLookupByLibrary.simpleMessage("Errore: "),
     "premiumHeader": MessageLookupByLibrary.simpleMessage(
       "Solo utenti Premium:",
@@ -119,12 +124,17 @@ class MessageLookup extends MessageLookupByLibrary {
     "privacyPolicyLink": MessageLookupByLibrary.simpleMessage(
       "Informativa sulla privacy",
     ),
+    "remainingFilamentLabel": MessageLookupByLibrary.simpleMessage(
+      "Filamento rimanente",
+    ),
+    "remainingLabel": MessageLookupByLibrary.simpleMessage("Rimanente:"),
     "purchaseError": MessageLookupByLibrary.simpleMessage(
       "Si è verificato un errore durante l\'elaborazione dell\'acquisto. Riprova più tardi.",
     ),
     "restorePurchases": MessageLookupByLibrary.simpleMessage(
       "Ripristina acquisti",
     ),
+    "retryButton": MessageLookupByLibrary.simpleMessage("Riprova"),
     "resultElectricityPrefix": MessageLookupByLibrary.simpleMessage(
       "Costo totale per l\'elettricità: ",
     ),
@@ -138,6 +148,12 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "saveButton": MessageLookupByLibrary.simpleMessage("Salva"),
     "savePrintButton": MessageLookupByLibrary.simpleMessage("Salva stampa"),
+    "savePrintErrorMessage": MessageLookupByLibrary.simpleMessage(
+      "Errore durante il salvataggio della stampa",
+    ),
+    "savePrintSuccessMessage": MessageLookupByLibrary.simpleMessage(
+      "Stampa salvata",
+    ),
     "searchMaterialsHint": MessageLookupByLibrary.simpleMessage(
       "Cerca materiali",
     ),
@@ -160,6 +176,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "supportEmail": MessageLookupByLibrary.simpleMessage("google@remej.dev"),
     "supportEmailPrefix": MessageLookupByLibrary.simpleMessage(
       "Per qualsiasi problema, scrivimi a ",
+    ),
+    "trackRemainingFilamentLabel": MessageLookupByLibrary.simpleMessage(
+      "Tieni traccia del filamento rimanente",
     ),
     "supportIdCopied": MessageLookupByLibrary.simpleMessage(
       "ID di supporto copiato",

--- a/lib/generated/intl/messages_ja.dart
+++ b/lib/generated/intl/messages_ja.dart
@@ -26,6 +26,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m2(version) => "バージョン ${version}";
 
+  static String m3(error) => "材料の読み込みに失敗しました: ${error}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
     "addAtLeastOneMaterial": MessageLookupByLibrary.simpleMessage(
@@ -72,6 +74,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "materialBreakdownLabel": MessageLookupByLibrary.simpleMessage("素材内訳"),
     "materialFallback": MessageLookupByLibrary.simpleMessage("材料"),
+    "materialsLoadError": m3,
     "materialNameLabel": MessageLookupByLibrary.simpleMessage("材料名 *"),
     "materialNone": MessageLookupByLibrary.simpleMessage("なし"),
     "materialWeightExplanation": MessageLookupByLibrary.simpleMessage(
@@ -81,6 +84,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "materialsHeader": MessageLookupByLibrary.simpleMessage("材料"),
     "minutesLabel": MessageLookupByLibrary.simpleMessage("分"),
     "needHelpTitle": MessageLookupByLibrary.simpleMessage("ヘルプが必要ですか？"),
+    "numberExampleHint": MessageLookupByLibrary.simpleMessage("例: 123"),
     "offeringsError": MessageLookupByLibrary.simpleMessage("エラー: "),
     "premiumHeader": MessageLookupByLibrary.simpleMessage("プレミアムユーザーのみ:"),
     "printNameHint": MessageLookupByLibrary.simpleMessage("プリント名"),
@@ -88,10 +92,13 @@ class MessageLookup extends MessageLookupByLibrary {
     "printerNameLabel": MessageLookupByLibrary.simpleMessage("名前 *"),
     "printersHeader": MessageLookupByLibrary.simpleMessage("プリンター"),
     "privacyPolicyLink": MessageLookupByLibrary.simpleMessage("プライバシーポリシー"),
+    "remainingFilamentLabel": MessageLookupByLibrary.simpleMessage("残りフィラメント"),
+    "remainingLabel": MessageLookupByLibrary.simpleMessage("残量:"),
     "purchaseError": MessageLookupByLibrary.simpleMessage(
       "購入処理中にエラーが発生しました。後でもう一度お試しください。",
     ),
     "restorePurchases": MessageLookupByLibrary.simpleMessage("購入を復元"),
+    "retryButton": MessageLookupByLibrary.simpleMessage("再試行"),
     "resultElectricityPrefix": MessageLookupByLibrary.simpleMessage("電気代合計:"),
     "resultFilamentPrefix": MessageLookupByLibrary.simpleMessage(
       "フィラメントの合計コスト:",
@@ -101,6 +108,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "riskTotalPrefix": MessageLookupByLibrary.simpleMessage("リスクコスト:"),
     "saveButton": MessageLookupByLibrary.simpleMessage("保存"),
     "savePrintButton": MessageLookupByLibrary.simpleMessage("プリントを保存"),
+    "savePrintErrorMessage": MessageLookupByLibrary.simpleMessage(
+      "プリントの保存中にエラーが発生しました",
+    ),
+    "savePrintSuccessMessage": MessageLookupByLibrary.simpleMessage(
+      "プリントを保存しました",
+    ),
     "searchMaterialsHint": MessageLookupByLibrary.simpleMessage("素材を検索"),
     "selectMaterialHint": MessageLookupByLibrary.simpleMessage("カスタム（未保存）"),
     "selectPrinterHint": MessageLookupByLibrary.simpleMessage("プリンターを選択"),
@@ -113,6 +126,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "supportEmail": MessageLookupByLibrary.simpleMessage("google@remej.dev"),
     "supportEmailPrefix": MessageLookupByLibrary.simpleMessage(
       "問題がある場合は、次のアドレスまでメールしてください: ",
+    ),
+    "trackRemainingFilamentLabel": MessageLookupByLibrary.simpleMessage(
+      "残りフィラメントを追跡",
     ),
     "supportIdCopied": MessageLookupByLibrary.simpleMessage("サポートIDをコピーしました"),
     "supportIdLabel": MessageLookupByLibrary.simpleMessage("サポートIDを含めてください: "),

--- a/lib/generated/intl/messages_nl.dart
+++ b/lib/generated/intl/messages_nl.dart
@@ -27,6 +27,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m2(version) => "Versie ${version}";
 
+  static String m3(error) => "Fout bij laden van materialen: ${error}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
     "addAtLeastOneMaterial": MessageLookupByLibrary.simpleMessage(
@@ -91,6 +93,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Materiaaluitsplitsing",
     ),
     "materialFallback": MessageLookupByLibrary.simpleMessage("Materiaal"),
+    "materialsLoadError": m3,
     "materialNameLabel": MessageLookupByLibrary.simpleMessage(
       "Materiaalnaam *",
     ),
@@ -102,6 +105,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "materialsHeader": MessageLookupByLibrary.simpleMessage("Materialen"),
     "minutesLabel": MessageLookupByLibrary.simpleMessage("Notulen"),
     "needHelpTitle": MessageLookupByLibrary.simpleMessage("Hulp nodig?"),
+    "numberExampleHint": MessageLookupByLibrary.simpleMessage("bijv. 123"),
     "offeringsError": MessageLookupByLibrary.simpleMessage("Fout: "),
     "premiumHeader": MessageLookupByLibrary.simpleMessage(
       "Alleen voor Premium-gebruikers:",
@@ -113,12 +117,17 @@ class MessageLookup extends MessageLookupByLibrary {
     "printerNameLabel": MessageLookupByLibrary.simpleMessage("Naam *"),
     "printersHeader": MessageLookupByLibrary.simpleMessage("3D-printers"),
     "privacyPolicyLink": MessageLookupByLibrary.simpleMessage("Privacybeleid"),
+    "remainingFilamentLabel": MessageLookupByLibrary.simpleMessage(
+      "Resterend filament",
+    ),
+    "remainingLabel": MessageLookupByLibrary.simpleMessage("Resterend:"),
     "purchaseError": MessageLookupByLibrary.simpleMessage(
       "Er is een fout opgetreden bij het verwerken van je aankoop. Probeer het later opnieuw.",
     ),
     "restorePurchases": MessageLookupByLibrary.simpleMessage(
       "Aankopen herstellen",
     ),
+    "retryButton": MessageLookupByLibrary.simpleMessage("Opnieuw proberen"),
     "resultElectricityPrefix": MessageLookupByLibrary.simpleMessage(
       "Totale kosten voor elektriciteit:",
     ),
@@ -130,6 +139,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "riskTotalPrefix": MessageLookupByLibrary.simpleMessage("Risicokosten:"),
     "saveButton": MessageLookupByLibrary.simpleMessage("Opslaan"),
     "savePrintButton": MessageLookupByLibrary.simpleMessage("Print opslaan"),
+    "savePrintErrorMessage": MessageLookupByLibrary.simpleMessage(
+      "Fout bij opslaan van print",
+    ),
+    "savePrintSuccessMessage": MessageLookupByLibrary.simpleMessage(
+      "Print opgeslagen",
+    ),
     "searchMaterialsHint": MessageLookupByLibrary.simpleMessage(
       "Materialen zoeken",
     ),
@@ -150,6 +165,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "supportEmail": MessageLookupByLibrary.simpleMessage("google@remej.dev"),
     "supportEmailPrefix": MessageLookupByLibrary.simpleMessage(
       "Bij problemen kun je mij mailen op ",
+    ),
+    "trackRemainingFilamentLabel": MessageLookupByLibrary.simpleMessage(
+      "Resterend filament bijhouden",
     ),
     "supportIdCopied": MessageLookupByLibrary.simpleMessage(
       "Support-ID gekopieerd",

--- a/lib/generated/intl/messages_pt.dart
+++ b/lib/generated/intl/messages_pt.dart
@@ -27,6 +27,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m2(version) => "Versão ${version}";
 
+  static String m3(error) => "Erro ao carregar materiais: ${error}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
     "addAtLeastOneMaterial": MessageLookupByLibrary.simpleMessage(
@@ -91,6 +93,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Detalhamento de materiais",
     ),
     "materialFallback": MessageLookupByLibrary.simpleMessage("Material padrão"),
+    "materialsLoadError": m3,
     "materialNameLabel": MessageLookupByLibrary.simpleMessage(
       "Nome do material *",
     ),
@@ -102,6 +105,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "materialsHeader": MessageLookupByLibrary.simpleMessage("Materiais"),
     "minutesLabel": MessageLookupByLibrary.simpleMessage("Minutos"),
     "needHelpTitle": MessageLookupByLibrary.simpleMessage("Precisa de ajuda?"),
+    "numberExampleHint": MessageLookupByLibrary.simpleMessage("ex.: 123"),
     "offeringsError": MessageLookupByLibrary.simpleMessage("Erro: "),
     "premiumHeader": MessageLookupByLibrary.simpleMessage(
       "Apenas usuários premium:",
@@ -115,12 +119,17 @@ class MessageLookup extends MessageLookupByLibrary {
     "privacyPolicyLink": MessageLookupByLibrary.simpleMessage(
       "Política de Privacidade",
     ),
+    "remainingFilamentLabel": MessageLookupByLibrary.simpleMessage(
+      "Filamento restante",
+    ),
+    "remainingLabel": MessageLookupByLibrary.simpleMessage("Restante:"),
     "purchaseError": MessageLookupByLibrary.simpleMessage(
       "Houve um erro ao processar sua compra. Tente novamente mais tarde.",
     ),
     "restorePurchases": MessageLookupByLibrary.simpleMessage(
       "Restaurar compras",
     ),
+    "retryButton": MessageLookupByLibrary.simpleMessage("Tentar novamente"),
     "resultElectricityPrefix": MessageLookupByLibrary.simpleMessage(
       "Custo total de eletricidade: ",
     ),
@@ -132,6 +141,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "riskTotalPrefix": MessageLookupByLibrary.simpleMessage("Custo do risco: "),
     "saveButton": MessageLookupByLibrary.simpleMessage("Salvar"),
     "savePrintButton": MessageLookupByLibrary.simpleMessage("Salvar impressão"),
+    "savePrintErrorMessage": MessageLookupByLibrary.simpleMessage(
+      "Erro ao salvar a impressão",
+    ),
+    "savePrintSuccessMessage": MessageLookupByLibrary.simpleMessage(
+      "Impressão salva",
+    ),
     "searchMaterialsHint": MessageLookupByLibrary.simpleMessage(
       "Pesquisar materiais",
     ),
@@ -156,6 +171,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "supportEmail": MessageLookupByLibrary.simpleMessage("google@remej.dev"),
     "supportEmailPrefix": MessageLookupByLibrary.simpleMessage(
       "Em caso de problemas, envie um e-mail para ",
+    ),
+    "trackRemainingFilamentLabel": MessageLookupByLibrary.simpleMessage(
+      "Monitorar filamento restante",
     ),
     "supportIdCopied": MessageLookupByLibrary.simpleMessage(
       "ID de suporte copiado",

--- a/lib/generated/intl/messages_th.dart
+++ b/lib/generated/intl/messages_th.dart
@@ -26,6 +26,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m2(version) => "เวอร์ชัน ${version}";
 
+  static String m3(error) => "โหลดวัสดุไม่สำเร็จ: ${error}";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
     "addAtLeastOneMaterial": MessageLookupByLibrary.simpleMessage(
@@ -84,6 +86,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "รายละเอียดวัสดุ",
     ),
     "materialFallback": MessageLookupByLibrary.simpleMessage("วัสดุ"),
+    "materialsLoadError": m3,
     "materialNameLabel": MessageLookupByLibrary.simpleMessage("ชื่อวัสดุ *"),
     "materialNone": MessageLookupByLibrary.simpleMessage("ไม่มี"),
     "materialWeightExplanation": MessageLookupByLibrary.simpleMessage(
@@ -95,6 +98,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "needHelpTitle": MessageLookupByLibrary.simpleMessage(
       "ต้องการความช่วยเหลือ?",
     ),
+    "numberExampleHint": MessageLookupByLibrary.simpleMessage("เช่น 123"),
     "offeringsError": MessageLookupByLibrary.simpleMessage("ข้อผิดพลาด: "),
     "premiumHeader": MessageLookupByLibrary.simpleMessage(
       "ผู้ใช้ระดับพรีเมียมเท่านั้น:",
@@ -108,10 +112,15 @@ class MessageLookup extends MessageLookupByLibrary {
     "privacyPolicyLink": MessageLookupByLibrary.simpleMessage(
       "นโยบายความเป็นส่วนตัว",
     ),
+    "remainingFilamentLabel": MessageLookupByLibrary.simpleMessage(
+      "ฟิลาเมนต์คงเหลือ",
+    ),
+    "remainingLabel": MessageLookupByLibrary.simpleMessage("คงเหลือ:"),
     "purchaseError": MessageLookupByLibrary.simpleMessage(
       "เกิดข้อผิดพลาดในการประมวลผลการซื้อของคุณ โปรดลองอีกครั้งในภายหลัง",
     ),
     "restorePurchases": MessageLookupByLibrary.simpleMessage("กู้คืนการซื้อ"),
+    "retryButton": MessageLookupByLibrary.simpleMessage("ลองอีกครั้ง"),
     "resultElectricityPrefix": MessageLookupByLibrary.simpleMessage(
       "ค่าไฟฟ้าทั้งหมด: ",
     ),
@@ -127,6 +136,12 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "saveButton": MessageLookupByLibrary.simpleMessage("บันทึก"),
     "savePrintButton": MessageLookupByLibrary.simpleMessage("บันทึกงานพิมพ์"),
+    "savePrintErrorMessage": MessageLookupByLibrary.simpleMessage(
+      "เกิดข้อผิดพลาดขณะบันทึกงานพิมพ์",
+    ),
+    "savePrintSuccessMessage": MessageLookupByLibrary.simpleMessage(
+      "บันทึกงานพิมพ์แล้ว",
+    ),
     "searchMaterialsHint": MessageLookupByLibrary.simpleMessage("ค้นหาวัสดุ"),
     "selectMaterialHint": MessageLookupByLibrary.simpleMessage(
       "กำหนดเอง (ยังไม่ได้บันทึก)",
@@ -145,6 +160,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "supportEmail": MessageLookupByLibrary.simpleMessage("google@remej.dev"),
     "supportEmailPrefix": MessageLookupByLibrary.simpleMessage(
       "หากมีปัญหา กรุณาส่งอีเมลมาที่ ",
+    ),
+    "trackRemainingFilamentLabel": MessageLookupByLibrary.simpleMessage(
+      "ติดตามฟิลาเมนต์คงเหลือ",
     ),
     "supportIdCopied": MessageLookupByLibrary.simpleMessage(
       "คัดลอกรหัสสนับสนุนแล้ว",

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -419,6 +419,71 @@ class S {
     return Intl.message('g', name: 'gramsSuffix', desc: '', args: []);
   }
 
+  /// `Remaining:`
+  String get remainingLabel {
+    return Intl.message(
+      'Remaining:',
+      name: 'remainingLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Track remaining filament`
+  String get trackRemainingFilamentLabel {
+    return Intl.message(
+      'Track remaining filament',
+      name: 'trackRemainingFilamentLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Remaining filament`
+  String get remainingFilamentLabel {
+    return Intl.message(
+      'Remaining filament',
+      name: 'remainingFilamentLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Error saving print`
+  String get savePrintErrorMessage {
+    return Intl.message(
+      'Error saving print',
+      name: 'savePrintErrorMessage',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Print saved`
+  String get savePrintSuccessMessage {
+    return Intl.message(
+      'Print saved',
+      name: 'savePrintSuccessMessage',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `e.g. 123`
+  String get numberExampleHint {
+    return Intl.message(
+      'e.g. 123',
+      name: 'numberExampleHint',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Retry`
+  String get retryButton {
+    return Intl.message('Retry', name: 'retryButton', desc: '', args: []);
+  }
+
   /// `w`
   String get wattsSuffix {
     return Intl.message('w', name: 'wattsSuffix', desc: '', args: []);
@@ -734,6 +799,16 @@ class S {
       name: 'materialsCountLabel',
       desc: '',
       args: [count],
+    );
+  }
+
+  /// `Failed to load materials: {error}`
+  String materialsLoadError(Object error) {
+    return Intl.message(
+      'Failed to load materials: $error',
+      name: 'materialsLoadError',
+      desc: '',
+      args: [error],
     );
   }
 

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -89,6 +89,26 @@
   "@materialNone": {},
   "gramsSuffix": "g",
   "@gramsSuffix": {},
+  "remainingLabel": "Verbleibend:",
+  "@remainingLabel": {},
+  "trackRemainingFilamentLabel": "Verbleibendes Filament verfolgen",
+  "@trackRemainingFilamentLabel": {},
+  "remainingFilamentLabel": "Verbleibendes Filament",
+  "@remainingFilamentLabel": {},
+  "savePrintErrorMessage": "Fehler beim Speichern des Drucks",
+  "@savePrintErrorMessage": {},
+  "savePrintSuccessMessage": "Druck gespeichert",
+  "@savePrintSuccessMessage": {},
+  "numberExampleHint": "z. B. 123",
+  "@numberExampleHint": {},
+  "materialsLoadError": "Fehler beim Laden der Materialien: {error}",
+  "@materialsLoadError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "retryButton": "Erneut versuchen",
+  "@retryButton": {},
   "wattsSuffix": "w",
   "@wattsSuffix": {},
   "needHelpTitle": "Brauchen Sie Hilfe?",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -45,6 +45,19 @@
   "selectMaterialHint": "Custom (unsaved)",
   "materialNone": "None",
   "gramsSuffix": "g",
+  "remainingLabel": "Remaining:",
+  "trackRemainingFilamentLabel": "Track remaining filament",
+  "remainingFilamentLabel": "Remaining filament",
+  "savePrintErrorMessage": "Error saving print",
+  "savePrintSuccessMessage": "Print saved",
+  "numberExampleHint": "e.g. 123",
+  "materialsLoadError": "Failed to load materials: {error}",
+  "@materialsLoadError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "retryButton": "Retry",
   "wattsSuffix": "w",
   "needHelpTitle": "Need Help?",
   "supportEmailPrefix": "For any issues, please mail me at ",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -89,6 +89,26 @@
   "@materialNone": {},
   "gramsSuffix": "g",
   "@gramsSuffix": {},
+  "remainingLabel": "Restante:",
+  "@remainingLabel": {},
+  "trackRemainingFilamentLabel": "Hacer seguimiento del filamento restante",
+  "@trackRemainingFilamentLabel": {},
+  "remainingFilamentLabel": "Filamento restante",
+  "@remainingFilamentLabel": {},
+  "savePrintErrorMessage": "Error al guardar la impresión",
+  "@savePrintErrorMessage": {},
+  "savePrintSuccessMessage": "Impresión guardada",
+  "@savePrintSuccessMessage": {},
+  "numberExampleHint": "p. ej. 123",
+  "@numberExampleHint": {},
+  "materialsLoadError": "Error al cargar los materiales: {error}",
+  "@materialsLoadError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "retryButton": "Reintentar",
+  "@retryButton": {},
   "wattsSuffix": "w",
   "@wattsSuffix": {},
   "needHelpTitle": "¿Necesitas ayuda?",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -90,6 +90,26 @@
   "@materialNone": {},
   "gramsSuffix": "g",
   "@gramsSuffix": {},
+  "remainingLabel": "Restant :",
+  "@remainingLabel": {},
+  "trackRemainingFilamentLabel": "Suivre le filament restant",
+  "@trackRemainingFilamentLabel": {},
+  "remainingFilamentLabel": "Filament restant",
+  "@remainingFilamentLabel": {},
+  "savePrintErrorMessage": "Erreur lors de l'enregistrement de l'impression",
+  "@savePrintErrorMessage": {},
+  "savePrintSuccessMessage": "Impression enregistrée",
+  "@savePrintSuccessMessage": {},
+  "numberExampleHint": "ex. 123",
+  "@numberExampleHint": {},
+  "materialsLoadError": "Échec du chargement des matériaux : {error}",
+  "@materialsLoadError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "retryButton": "Réessayer",
+  "@retryButton": {},
   "wattsSuffix": "w",
   "@wattsSuffix": {},
   "needHelpTitle": "Besoin d'aide ?",

--- a/lib/l10n/intl_id.arb
+++ b/lib/l10n/intl_id.arb
@@ -90,6 +90,26 @@
   "@materialNone": {},
   "gramsSuffix": "g",
   "@gramsSuffix": {},
+  "remainingLabel": "Sisa:",
+  "@remainingLabel": {},
+  "trackRemainingFilamentLabel": "Lacak sisa filamen",
+  "@trackRemainingFilamentLabel": {},
+  "remainingFilamentLabel": "Sisa filamen",
+  "@remainingFilamentLabel": {},
+  "savePrintErrorMessage": "Gagal menyimpan hasil cetak",
+  "@savePrintErrorMessage": {},
+  "savePrintSuccessMessage": "Hasil cetak disimpan",
+  "@savePrintSuccessMessage": {},
+  "numberExampleHint": "mis. 123",
+  "@numberExampleHint": {},
+  "materialsLoadError": "Gagal memuat material: {error}",
+  "@materialsLoadError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "retryButton": "Coba lagi",
+  "@retryButton": {},
   "wattsSuffix": "w",
   "@wattsSuffix": {},
   "needHelpTitle": "Butuh bantuan?",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -89,6 +89,26 @@
   "@materialNone": {},
   "gramsSuffix": "g",
   "@gramsSuffix": {},
+  "remainingLabel": "Rimanente:",
+  "@remainingLabel": {},
+  "trackRemainingFilamentLabel": "Tieni traccia del filamento rimanente",
+  "@trackRemainingFilamentLabel": {},
+  "remainingFilamentLabel": "Filamento rimanente",
+  "@remainingFilamentLabel": {},
+  "savePrintErrorMessage": "Errore durante il salvataggio della stampa",
+  "@savePrintErrorMessage": {},
+  "savePrintSuccessMessage": "Stampa salvata",
+  "@savePrintSuccessMessage": {},
+  "numberExampleHint": "es. 123",
+  "@numberExampleHint": {},
+  "materialsLoadError": "Errore durante il caricamento dei materiali: {error}",
+  "@materialsLoadError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "retryButton": "Riprova",
+  "@retryButton": {},
   "wattsSuffix": "w",
   "@wattsSuffix": {},
   "needHelpTitle": "Hai bisogno di aiuto?",

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -90,6 +90,26 @@
   "@materialNone": {},
   "gramsSuffix": "g",
   "@gramsSuffix": {},
+  "remainingLabel": "残量:",
+  "@remainingLabel": {},
+  "trackRemainingFilamentLabel": "残りフィラメントを追跡",
+  "@trackRemainingFilamentLabel": {},
+  "remainingFilamentLabel": "残りフィラメント",
+  "@remainingFilamentLabel": {},
+  "savePrintErrorMessage": "プリントの保存中にエラーが発生しました",
+  "@savePrintErrorMessage": {},
+  "savePrintSuccessMessage": "プリントを保存しました",
+  "@savePrintSuccessMessage": {},
+  "numberExampleHint": "例: 123",
+  "@numberExampleHint": {},
+  "materialsLoadError": "材料の読み込みに失敗しました: {error}",
+  "@materialsLoadError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "retryButton": "再試行",
+  "@retryButton": {},
   "wattsSuffix": "w",
   "@wattsSuffix": {},
   "needHelpTitle": "ヘルプが必要ですか？",

--- a/lib/l10n/intl_nl.arb
+++ b/lib/l10n/intl_nl.arb
@@ -90,6 +90,26 @@
   "@materialNone": {},
   "gramsSuffix": "g",
   "@gramsSuffix": {},
+  "remainingLabel": "Resterend:",
+  "@remainingLabel": {},
+  "trackRemainingFilamentLabel": "Resterend filament bijhouden",
+  "@trackRemainingFilamentLabel": {},
+  "remainingFilamentLabel": "Resterend filament",
+  "@remainingFilamentLabel": {},
+  "savePrintErrorMessage": "Fout bij opslaan van print",
+  "@savePrintErrorMessage": {},
+  "savePrintSuccessMessage": "Print opgeslagen",
+  "@savePrintSuccessMessage": {},
+  "numberExampleHint": "bijv. 123",
+  "@numberExampleHint": {},
+  "materialsLoadError": "Fout bij laden van materialen: {error}",
+  "@materialsLoadError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "retryButton": "Opnieuw proberen",
+  "@retryButton": {},
   "wattsSuffix": "w",
   "@wattsSuffix": {},
   "needHelpTitle": "Hulp nodig?",

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -89,6 +89,26 @@
   "@materialNone": {},
   "gramsSuffix": "g",
   "@gramsSuffix": {},
+  "remainingLabel": "Restante:",
+  "@remainingLabel": {},
+  "trackRemainingFilamentLabel": "Monitorar filamento restante",
+  "@trackRemainingFilamentLabel": {},
+  "remainingFilamentLabel": "Filamento restante",
+  "@remainingFilamentLabel": {},
+  "savePrintErrorMessage": "Erro ao salvar a impressão",
+  "@savePrintErrorMessage": {},
+  "savePrintSuccessMessage": "Impressão salva",
+  "@savePrintSuccessMessage": {},
+  "numberExampleHint": "ex.: 123",
+  "@numberExampleHint": {},
+  "materialsLoadError": "Erro ao carregar materiais: {error}",
+  "@materialsLoadError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "retryButton": "Tentar novamente",
+  "@retryButton": {},
   "wattsSuffix": "w",
   "@wattsSuffix": {},
   "needHelpTitle": "Precisa de ajuda?",

--- a/lib/l10n/intl_th.arb
+++ b/lib/l10n/intl_th.arb
@@ -90,6 +90,26 @@
   "@materialNone": {},
   "gramsSuffix": "g",
   "@gramsSuffix": {},
+  "remainingLabel": "คงเหลือ:",
+  "@remainingLabel": {},
+  "trackRemainingFilamentLabel": "ติดตามฟิลาเมนต์คงเหลือ",
+  "@trackRemainingFilamentLabel": {},
+  "remainingFilamentLabel": "ฟิลาเมนต์คงเหลือ",
+  "@remainingFilamentLabel": {},
+  "savePrintErrorMessage": "เกิดข้อผิดพลาดขณะบันทึกงานพิมพ์",
+  "@savePrintErrorMessage": {},
+  "savePrintSuccessMessage": "บันทึกงานพิมพ์แล้ว",
+  "@savePrintSuccessMessage": {},
+  "numberExampleHint": "เช่น 123",
+  "@numberExampleHint": {},
+  "materialsLoadError": "โหลดวัสดุไม่สำเร็จ: {error}",
+  "@materialsLoadError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "retryButton": "ลองอีกครั้ง",
+  "@retryButton": {},
   "wattsSuffix": "w",
   "@wattsSuffix": {},
   "needHelpTitle": "ต้องการความช่วยเหลือ?",

--- a/lib/settings/general_settings_form.dart
+++ b/lib/settings/general_settings_form.dart
@@ -8,6 +8,7 @@ import 'package:threed_print_cost_calculator/settings/model/general_settings_mod
 import 'package:threed_print_cost_calculator/app/components/focus_safe_text_field.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:threed_print_cost_calculator/shared/utils/number_parsing.dart';
+import 'package:threed_print_cost_calculator/shared/utils/text_input_normalizers.dart';
 
 class GeneralSettings extends HookConsumerWidget {
   const GeneralSettings({super.key});
@@ -129,6 +130,7 @@ class GeneralSettings extends HookConsumerWidget {
               externalText: data.electricityCost.toString(),
               focusNode: electricityFocus,
               keyboardType: TextInputType.number,
+              inputNormalizer: normalizeLeadingZeroNumericInput,
               decoration: InputDecoration(
                 labelText: l10n.electricityCostSettingsLabel,
                 suffixText: l10n.kwh,
@@ -146,6 +148,7 @@ class GeneralSettings extends HookConsumerWidget {
               externalText: data.wattage.toString(),
               focusNode: wattFocus,
               keyboardType: TextInputType.number,
+              inputNormalizer: normalizeLeadingZeroNumericInput,
               decoration: InputDecoration(
                 labelText: l10n.wattLabel,
                 suffixText: l10n.watt,

--- a/lib/settings/helpers/settings_helpers.dart
+++ b/lib/settings/helpers/settings_helpers.dart
@@ -1,6 +1,7 @@
 import 'package:bot_toast/bot_toast.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:sembast/sembast.dart';
+import 'package:threed_print_cost_calculator/generated/l10n.dart';
 import 'package:threed_print_cost_calculator/shared/providers/app_providers.dart';
 import 'package:threed_print_cost_calculator/settings/model/material_model.dart';
 
@@ -16,7 +17,7 @@ class SettingsHelpers {
     try {
       await store.add(db, value.toMap());
     } catch (e) {
-      BotToast.showText(text: 'Error saving print');
+      BotToast.showText(text: S.current.savePrintErrorMessage);
     }
   }
 }

--- a/lib/settings/materials/material_form.dart
+++ b/lib/settings/materials/material_form.dart
@@ -78,6 +78,7 @@ class MaterialForm extends HookConsumerWidget {
                     : '',
                 focusNode: weightFocus,
                 keyboardType: TextInputType.number,
+                inputNormalizer: normalizeLeadingZeroNumericInput,
                 decoration: InputDecoration(
                   labelText: l10n.weightLabel,
                   suffix: Text(l10n.gramsSuffix),

--- a/lib/settings/materials/material_form.dart
+++ b/lib/settings/materials/material_form.dart
@@ -5,6 +5,7 @@ import 'package:threed_print_cost_calculator/database/repositories/materials_rep
 import 'package:threed_print_cost_calculator/generated/l10n.dart';
 import 'package:threed_print_cost_calculator/settings/providers/materials_notifier.dart';
 import 'package:threed_print_cost_calculator/app/components/focus_safe_text_field.dart';
+import 'package:threed_print_cost_calculator/shared/utils/text_input_normalizers.dart';
 import 'package:threed_print_cost_calculator/shared/theme.dart';
 
 class MaterialForm extends HookConsumerWidget {
@@ -35,6 +36,13 @@ class MaterialForm extends HookConsumerWidget {
       text: state.weight.value != null ? state.weight.value.toString() : '',
     );
     final weightFocus = useFocusNode();
+
+    final remainingWeightController = useTextEditingController(
+      text: state.remainingWeight.value != null
+          ? state.remainingWeight.value.toString()
+          : '',
+    );
+    final remainingWeightFocus = useFocusNode();
 
     final costController = useTextEditingController(
       text: state.cost.value != null ? state.cost.value.toString() : '',
@@ -94,9 +102,39 @@ class MaterialForm extends HookConsumerWidget {
                     : '',
                 focusNode: costFocus,
                 keyboardType: TextInputType.number,
+                inputNormalizer: normalizeLeadingZeroNumericInput,
                 decoration: InputDecoration(labelText: l10n.costLabel),
                 onChanged: (v) => notifier.updateCost(v),
               ),
+
+              SwitchListTile.adaptive(
+                key: const ValueKey<String>(
+                  'settings.materials.track_remaining.toggle',
+                ),
+                contentPadding: EdgeInsets.zero,
+                title: Text(l10n.trackRemainingFilamentLabel),
+                value: state.autoDeductEnabled,
+                onChanged: notifier.updateAutoDeductEnabled,
+              ),
+
+              if (state.autoDeductEnabled)
+                FocusSafeTextField(
+                  key: const ValueKey<String>(
+                    'settings.materials.remaining_weight.input',
+                  ),
+                  controller: remainingWeightController,
+                  externalText: state.remainingWeight.value != null
+                      ? state.remainingWeight.value.toString()
+                      : '',
+                  focusNode: remainingWeightFocus,
+                  keyboardType: TextInputType.number,
+                  inputNormalizer: normalizeLeadingZeroNumericInput,
+                  decoration: InputDecoration(
+                    labelText: l10n.remainingFilamentLabel,
+                    suffix: Text(l10n.gramsSuffix),
+                  ),
+                  onChanged: notifier.updateRemainingWeight,
+                ),
 
               const SizedBox(height: 16),
               Row(

--- a/lib/settings/materials/materials.dart
+++ b/lib/settings/materials/materials.dart
@@ -14,6 +14,12 @@ class Materials extends HookConsumerWidget {
     final materialsRepository = ref.read(materialsRepositoryProvider);
     final l10n = S.of(context);
 
+    String formatWeight(num value) {
+      return value % 1 == 0
+          ? value.toStringAsFixed(0)
+          : value.toStringAsFixed(1);
+    }
+
     return ref
         .watch(materialsStreamProvider)
         .when(
@@ -85,6 +91,18 @@ class Materials extends HookConsumerWidget {
                                         .titleSmall
                                         ?.copyWith(fontSize: 12),
                                   ),
+                                  if (data.autoDeductEnabled)
+                                    Text(
+                                      key: ValueKey<String>(
+                                        'settings.materials.item.$index.remaining',
+                                      ),
+                                      '${l10n.remainingLabel} ${formatWeight(data.remainingWeight)}${l10n.gramsSuffix}',
+                                      overflow: TextOverflow.ellipsis,
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .titleSmall
+                                          ?.copyWith(fontSize: 12),
+                                    ),
                                 ],
                               ),
                             ),

--- a/lib/settings/materials/materials.dart
+++ b/lib/settings/materials/materials.dart
@@ -124,11 +124,11 @@ class Materials extends HookConsumerWidget {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Text('Failed to load materials: $error'),
+                Text(l10n.materialsLoadError(error.toString())),
                 const SizedBox(height: 8),
                 ElevatedButton(
                   onPressed: () => ref.invalidate(materialsStreamProvider),
-                  child: const Text('Retry'),
+                  child: Text(l10n.retryButton),
                 ),
               ],
             ),

--- a/lib/settings/model/material_model.dart
+++ b/lib/settings/model/material_model.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:threed_print_cost_calculator/shared/utils/number_parsing.dart';
 
 part 'material_model.freezed.dart';
 
@@ -11,9 +12,22 @@ abstract class MaterialModel with _$MaterialModel {
     required String color,
     required String weight,
     required bool archived,
+    @Default(false) bool autoDeductEnabled,
+    @Default(0) double originalWeight,
+    @Default(0) double remainingWeight,
   }) = _MaterialModel;
 
   factory MaterialModel.fromMap(Map<String, dynamic> map, String key) {
+    final parsedWeight = parseLocalizedNum(map['weight']).toDouble();
+    final hasOriginalWeight = map.containsKey('originalWeight');
+    final hasRemainingWeight = map.containsKey('remainingWeight');
+    final parsedOriginal = hasOriginalWeight
+        ? parseLocalizedNum(map['originalWeight']).toDouble()
+        : parsedWeight;
+    final parsedRemaining = hasRemainingWeight
+        ? parseLocalizedNum(map['remainingWeight']).toDouble()
+        : parsedWeight;
+
     return MaterialModel(
       id: key,
       name: map['name'].toString(),
@@ -21,12 +35,23 @@ abstract class MaterialModel with _$MaterialModel {
       color: map['color'].toString(),
       weight: (map['weight'] ?? 0).toString(),
       archived: false,
+      autoDeductEnabled: map['autoDeductEnabled'] == true,
+      originalWeight: parsedOriginal,
+      remainingWeight: parsedRemaining,
     );
   }
 }
 
 extension MaterialModelX on MaterialModel {
   Map<String, dynamic> toMap() {
-    return {'name': name, 'cost': cost, 'color': color, 'weight': weight};
+    return {
+      'name': name,
+      'cost': cost,
+      'color': color,
+      'weight': weight,
+      'autoDeductEnabled': autoDeductEnabled,
+      'originalWeight': originalWeight,
+      'remainingWeight': remainingWeight,
+    };
   }
 }

--- a/lib/settings/printers/add_printer.dart
+++ b/lib/settings/printers/add_printer.dart
@@ -4,6 +4,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:threed_print_cost_calculator/generated/l10n.dart';
 import 'package:threed_print_cost_calculator/settings/providers/printers_notifier.dart';
 import 'package:threed_print_cost_calculator/app/components/focus_safe_text_field.dart';
+import 'package:threed_print_cost_calculator/shared/utils/text_input_normalizers.dart';
 import 'package:threed_print_cost_calculator/shared/theme.dart';
 
 class AddPrinter extends HookConsumerWidget {
@@ -65,6 +66,7 @@ class AddPrinter extends HookConsumerWidget {
                 externalText: state.wattage.value,
                 focusNode: wattFocus,
                 keyboardType: TextInputType.number,
+                inputNormalizer: normalizeLeadingZeroNumericInput,
                 decoration: InputDecoration(labelText: l10n.wattageLabel),
                 onChanged: notifier.updateWattage,
               ),

--- a/lib/settings/providers/materials_notifier.dart
+++ b/lib/settings/providers/materials_notifier.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:riverpod/riverpod.dart';
 import 'package:threed_print_cost_calculator/database/repositories/materials_repository.dart';
 import 'package:threed_print_cost_calculator/shared/components/num_input.dart';
@@ -25,10 +27,16 @@ class MaterialsProvider extends Notifier<MaterialState> {
       final material = await _materialsRepository.getMaterialById(key);
       if (material == null) return;
 
-      updateName(material.name);
-      updateColor(material.color);
-      updateCost(material.cost.toString());
-      updateWeight(material.weight.toString());
+      state = state.copyWith(
+        name: StringInput.dirty(value: material.name),
+        color: StringInput.dirty(value: material.color),
+        cost: NumberInput.dirty(value: parseLocalizedNum(material.cost)),
+        weight: NumberInput.dirty(value: parseLocalizedNum(material.weight)),
+        autoDeductEnabled: material.autoDeductEnabled,
+        remainingWeight: material.autoDeductEnabled
+            ? NumberInput.dirty(value: material.remainingWeight)
+            : const NumberInput.pure(),
+      );
     }
   }
 
@@ -47,12 +55,40 @@ class MaterialsProvider extends Notifier<MaterialState> {
   }
 
   void updateWeight(String value) {
+    final parsedValue = parseLocalizedNum(value);
     state = state.copyWith(
-      weight: NumberInput.dirty(value: parseLocalizedNum(value)),
+      weight: NumberInput.dirty(value: parsedValue),
+      remainingWeight: state.autoDeductEnabled
+          ? state.remainingWeight
+          : NumberInput.dirty(value: math.max(0, parsedValue)),
+    );
+  }
+
+  void updateAutoDeductEnabled(bool value) {
+    state = state.copyWith(
+      autoDeductEnabled: value,
+      remainingWeight: value
+          ? NumberInput.dirty(value: math.max(0, state.weight.value ?? 0))
+          : const NumberInput.pure(),
+    );
+  }
+
+  void updateRemainingWeight(String value) {
+    state = state.copyWith(
+      remainingWeight: NumberInput.dirty(
+        value: math.max(0, parseLocalizedNum(value)),
+      ),
     );
   }
 
   Future<Object?> submit(String? dbRef) async {
+    final existing = dbRef == null
+        ? null
+        : await _materialsRepository.getMaterialById(dbRef);
+    final parsedWeight = (state.weight.value ?? 0).toDouble();
+    final wasTrackingEnabled = existing?.autoDeductEnabled ?? false;
+    final isTrackingEnabled = state.autoDeductEnabled;
+
     final material = MaterialModel(
       id: dbRef ?? '',
       name: state.name.value,
@@ -60,6 +96,16 @@ class MaterialsProvider extends Notifier<MaterialState> {
       color: state.color.value,
       weight: state.weight.value.toString(),
       archived: false,
+      autoDeductEnabled: isTrackingEnabled,
+      originalWeight: isTrackingEnabled && wasTrackingEnabled
+          ? existing!.originalWeight
+          : parsedWeight,
+      remainingWeight: isTrackingEnabled
+          ? math.max(
+              0,
+              (state.remainingWeight.value ?? parsedWeight).toDouble(),
+            )
+          : parsedWeight,
     );
 
     final key = await _materialsRepository.saveMaterial(material, id: dbRef);

--- a/lib/settings/state/material_state.dart
+++ b/lib/settings/state/material_state.dart
@@ -7,12 +7,16 @@ class MaterialState with FormzMixin {
   final NumberInput cost;
   final StringInput color;
   final NumberInput weight;
+  final bool autoDeductEnabled;
+  final NumberInput remainingWeight;
 
   MaterialState({
     this.name = const StringInput.pure(),
     this.cost = const NumberInput.pure(),
     this.color = const StringInput.pure(),
     this.weight = const NumberInput.pure(),
+    this.autoDeductEnabled = false,
+    this.remainingWeight = const NumberInput.pure(),
   });
 
   MaterialState copyWith({
@@ -20,15 +24,19 @@ class MaterialState with FormzMixin {
     NumberInput? cost,
     StringInput? color,
     NumberInput? weight,
+    bool? autoDeductEnabled,
+    NumberInput? remainingWeight,
   }) {
     return MaterialState(
       name: name ?? this.name,
       cost: cost ?? this.cost,
       color: color ?? this.color,
       weight: weight ?? this.weight,
+      autoDeductEnabled: autoDeductEnabled ?? this.autoDeductEnabled,
+      remainingWeight: remainingWeight ?? this.remainingWeight,
     );
   }
 
   @override
-  List<FormzInput> get inputs => [name, cost, color, weight];
+  List<FormzInput> get inputs => [name, cost, color, weight, remainingWeight];
 }

--- a/lib/settings/work_costs_form.dart
+++ b/lib/settings/work_costs_form.dart
@@ -9,6 +9,7 @@ import 'package:threed_print_cost_calculator/database/repositories/settings_repo
 import 'package:threed_print_cost_calculator/generated/l10n.dart';
 import 'package:threed_print_cost_calculator/settings/model/general_settings_model.dart';
 import 'package:threed_print_cost_calculator/shared/utils/number_parsing.dart';
+import 'package:threed_print_cost_calculator/shared/utils/text_input_normalizers.dart';
 
 class WorkCostsSettings extends HookConsumerWidget {
   const WorkCostsSettings({super.key});
@@ -153,6 +154,7 @@ class WorkCostsSettings extends HookConsumerWidget {
                   inputFormatters: [
                     FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
                   ],
+                  inputNormalizer: normalizeLeadingZeroNumericInput,
                   validator: (value) {
                     if (normalizeLocalizedNumber(value).isEmpty) {
                       return l10n.enterNumber;
@@ -182,6 +184,7 @@ class WorkCostsSettings extends HookConsumerWidget {
                   inputFormatters: [
                     FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
                   ],
+                  inputNormalizer: normalizeLeadingZeroNumericInput,
                   validator: (value) {
                     if (normalizeLocalizedNumber(value).isEmpty) {
                       return l10n.enterNumber;
@@ -210,6 +213,7 @@ class WorkCostsSettings extends HookConsumerWidget {
                   inputFormatters: [
                     FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
                   ],
+                  inputNormalizer: normalizeLeadingZeroNumericInput,
                   validator: (value) {
                     if (normalizeLocalizedNumber(value).isEmpty) {
                       return l10n.enterNumber;

--- a/lib/shared/utils/text_input_normalizers.dart
+++ b/lib/shared/utils/text_input_normalizers.dart
@@ -1,0 +1,28 @@
+String normalizeLeadingZeroNumericInput(
+  String text, {
+  bool allowDecimal = true,
+}) {
+  if (text.isEmpty) return text;
+
+  if (allowDecimal) {
+    final separatorIndex = text.indexOf(RegExp(r'[\.,]'));
+    if (separatorIndex != -1) {
+      final wholePart = text.substring(0, separatorIndex);
+      final fractionalPart = text.substring(separatorIndex);
+      final normalizedWholePart = _normalizeIntegerPart(wholePart);
+      return '$normalizedWholePart$fractionalPart';
+    }
+  }
+
+  return _normalizeIntegerPart(text);
+}
+
+String _normalizeIntegerPart(String text) {
+  if (text.isEmpty) return '0';
+  if (text.length <= 1 || !RegExp(r'^0+\d+$').hasMatch(text)) {
+    return text;
+  }
+
+  final normalized = text.replaceFirst(RegExp(r'^0+'), '');
+  return normalized.isEmpty ? '0' : normalized;
+}

--- a/test/app/components/focus_safe_text_field_test.dart
+++ b/test/app/components/focus_safe_text_field_test.dart
@@ -65,6 +65,31 @@ void main() {
     focusNode.dispose();
     controller.dispose();
   });
+
+  testWidgets('normalizes leading zeros before onChanged', (tester) async {
+    final controller = TextEditingController();
+    String? changedValue;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: FocusSafeTextField(
+            controller: controller,
+            externalText: '',
+            inputNormalizer: (value) => value.replaceFirst(RegExp(r'^0+'), ''),
+            onChanged: (value) => changedValue = value,
+          ),
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextFormField), '01000');
+    await tester.pump();
+
+    expect(controller.text, '1000');
+    expect(changedValue, '1000');
+    controller.dispose();
+  });
 }
 
 class _Host extends StatefulWidget {

--- a/test/calculator/helpers/calculator_helpers_test.dart
+++ b/test/calculator/helpers/calculator_helpers_test.dart
@@ -1,9 +1,100 @@
+import 'package:bot_toast/bot_toast.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:threed_print_cost_calculator/calculator/helpers/calculator_helpers.dart';
 import 'package:threed_print_cost_calculator/calculator/model/material_usage_input.dart';
+import 'package:threed_print_cost_calculator/core/logging/app_logger.dart';
+import 'package:threed_print_cost_calculator/database/repositories/history_repository.dart';
+import 'package:threed_print_cost_calculator/database/services/material_stock_service.dart';
+import 'package:threed_print_cost_calculator/history/model/history_model.dart';
+
+class _RecordingHistoryRepository extends HistoryRepository {
+  _RecordingHistoryRepository(super.ref, {this.shouldThrow = false});
+
+  final bool shouldThrow;
+  final List<HistoryModel> saved = [];
+
+  @override
+  Future<Object?> saveHistory(HistoryModel model) async {
+    if (shouldThrow) {
+      throw Exception('save failed');
+    }
+
+    saved.add(model);
+    return 1;
+  }
+}
+
+class _RecordingMaterialStockService extends MaterialStockService {
+  _RecordingMaterialStockService(super.ref, {this.shouldThrow = false});
+
+  final bool shouldThrow;
+  final List<HistoryModel> deducted = [];
+
+  @override
+  Future<void> deductForSavedHistory(HistoryModel history) async {
+    if (shouldThrow) {
+      throw Exception('deduction failed');
+    }
+
+    deducted.add(history);
+  }
+}
+
+class _RecordingLogSink extends AppLogSink {
+  final List<AppLogEvent> events = [];
+
+  @override
+  void log(AppLogEvent event) {
+    events.add(event);
+  }
+}
+
+HistoryModel _buildHistoryModel() {
+  return HistoryModel(
+    name: 'Saved print',
+    totalCost: 10,
+    riskCost: 1,
+    filamentCost: 5,
+    electricityCost: 2,
+    labourCost: 2,
+    date: DateTime.parse('2024-01-01T00:00:00.000Z'),
+    printer: 'Printer',
+    material: 'PLA',
+    weight: 100,
+    materialUsages: const [
+      {
+        'materialId': 'mat-1',
+        'materialName': 'PLA',
+        'costPerKg': 20,
+        'weightGrams': 100,
+      },
+    ],
+    timeHours: '01:00',
+  );
+}
+
+Future<void> _pumpToastApp(
+  WidgetTester tester,
+  ProviderContainer container,
+) async {
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        builder: BotToastInit(),
+        navigatorObservers: [BotToastNavigatorObserver()],
+        home: const Scaffold(body: SizedBox.shrink()),
+      ),
+    ),
+  );
+  await tester.pump();
+}
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   late ProviderContainer container;
 
   setUp(() {
@@ -132,6 +223,90 @@ void main() {
 
       // Per-item rounding should produce exactly 0.02
       expect(result, equals(0.02));
+    },
+  );
+
+  testWidgets('savePrint skips stock deduction when history save fails', (
+    tester,
+  ) async {
+    late _RecordingHistoryRepository historyRepository;
+    _RecordingMaterialStockService? stockService;
+    final overrideContainer = ProviderContainer(
+      overrides: [
+        historyRepositoryProvider.overrideWith((ref) {
+          historyRepository = _RecordingHistoryRepository(
+            ref,
+            shouldThrow: true,
+          );
+          return historyRepository;
+        }),
+        materialStockServiceProvider.overrideWith((ref) {
+          final service = _RecordingMaterialStockService(ref);
+          stockService = service;
+          return service;
+        }),
+      ],
+    );
+    addTearDown(overrideContainer.dispose);
+
+    await _pumpToastApp(tester, overrideContainer);
+    await overrideContainer
+        .read(calculatorHelpersProvider)
+        .savePrint(_buildHistoryModel());
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 3));
+
+    expect(historyRepository.saved, isEmpty);
+    expect(stockService, isNull);
+  });
+
+  testWidgets(
+    'savePrint logs warning and keeps success path when deduction fails',
+    (tester) async {
+      final logSink = _RecordingLogSink();
+      late _RecordingHistoryRepository historyRepository;
+      late _RecordingMaterialStockService stockService;
+      final overrideContainer = ProviderContainer(
+        overrides: [
+          historyRepositoryProvider.overrideWith((ref) {
+            historyRepository = _RecordingHistoryRepository(ref);
+            return historyRepository;
+          }),
+          materialStockServiceProvider.overrideWith((ref) {
+            stockService = _RecordingMaterialStockService(
+              ref,
+              shouldThrow: true,
+            );
+            return stockService;
+          }),
+          appLogSinkProvider.overrideWithValue(logSink),
+          appLoggerConfigProvider.overrideWithValue(
+            const AppLoggerConfig(minLevel: AppLogLevel.debug),
+          ),
+        ],
+      );
+      addTearDown(overrideContainer.dispose);
+
+      await _pumpToastApp(tester, overrideContainer);
+
+      final history = _buildHistoryModel();
+      await overrideContainer
+          .read(calculatorHelpersProvider)
+          .savePrint(history);
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 3));
+
+      expect(historyRepository.saved, [history]);
+      expect(stockService.deducted, isEmpty);
+      expect(
+        logSink.events.any(
+          (event) =>
+              event.level == AppLogLevel.warn &&
+              event.message ==
+                  'History saved but material stock deduction failed',
+        ),
+        isTrue,
+      );
     },
   );
 }

--- a/test/calculator/view/components/duration_dialog_test.dart
+++ b/test/calculator/view/components/duration_dialog_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:threed_print_cost_calculator/calculator/view/components/duration_dialog.dart';
+import 'package:threed_print_cost_calculator/generated/l10n.dart';
+
+import '../../../helpers/helpers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await setupTest();
+  });
+
+  testWidgets('hours and minutes strip leading zeros', (tester) async {
+    late S l10n;
+    final db = await tester.pumpApp(
+      Builder(
+        builder: (context) {
+          l10n = S.of(context);
+          return DurationDialog(initialHours: 0, initialMinutes: 0, l10n: l10n);
+        },
+      ),
+    );
+    addTearDown(db.close);
+
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('calculator.duration.hours.input')),
+      '007',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('calculator.duration.minutes.input')),
+      '09',
+    );
+    await tester.pump();
+
+    expect(
+      tester
+          .widget<TextFormField>(
+            find.byKey(
+              const ValueKey<String>('calculator.duration.hours.input'),
+            ),
+          )
+          .controller!
+          .text,
+      '7',
+    );
+    expect(
+      tester
+          .widget<TextFormField>(
+            find.byKey(
+              const ValueKey<String>('calculator.duration.minutes.input'),
+            ),
+          )
+          .controller!
+          .text,
+      '9',
+    );
+  });
+}

--- a/test/calculator/view/components/materials_selection/material_row_test.dart
+++ b/test/calculator/view/components/materials_selection/material_row_test.dart
@@ -31,6 +31,9 @@ class _MaterialRowHarnessState extends State<_MaterialRowHarness> {
     color: '#FFFFFF',
     weight: '1000',
     archived: false,
+    autoDeductEnabled: true,
+    originalWeight: 1000,
+    remainingWeight: 875,
   );
 
   @override
@@ -70,6 +73,9 @@ void main() {
         color: '#FFFFFF',
         weight: '1000',
         archived: false,
+        autoDeductEnabled: true,
+        originalWeight: 1000,
+        remainingWeight: 875,
       );
 
       int? updatedWeight;
@@ -91,6 +97,7 @@ void main() {
 
       // The weight field should show initial value
       expect(find.text('50'), findsOneWidget);
+      expect(find.text('Remaining: 875g'), findsOneWidget);
       expect(find.byType(FocusSafeTextField), findsOneWidget);
 
       // Change weight

--- a/test/calculator/view/material_select_test.dart
+++ b/test/calculator/view/material_select_test.dart
@@ -28,6 +28,20 @@ void main() {
     );
   }
 
+  MaterialModel trackedMaterial(String id, String name, String color) {
+    return MaterialModel(
+      id: id,
+      name: name,
+      cost: '20',
+      color: color,
+      weight: '1000',
+      archived: false,
+      autoDeductEnabled: true,
+      originalWeight: 1000,
+      remainingWeight: 640,
+    );
+  }
+
   testWidgets('stale selected material is ignored when missing', (
     tester,
   ) async {
@@ -89,5 +103,29 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(DropdownButton<String>), findsNothing);
+  });
+
+  testWidgets('shows remaining stock only for tracked selected material', (
+    tester,
+  ) async {
+    await tester.pumpApp(const MaterialSelect(), [
+      settingsRepositoryProvider.overrideWithValue(
+        FakeSettingsRepository(
+          initialSettings: GeneralSettingsModel.initial().copyWith(
+            selectedMaterial: 'mat-a',
+          ),
+        ),
+      ),
+      materialsStreamProvider.overrideWith(
+        (ref) => Stream.value([
+          trackedMaterial('mat-a', 'PLA', '#FFFFFF'),
+          material('mat-b', 'ABS', '#000000'),
+        ]),
+      ),
+    ]);
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Remaining: 640g'), findsOneWidget);
   });
 }

--- a/test/calculator/view/save_form_test.dart
+++ b/test/calculator/view/save_form_test.dart
@@ -244,6 +244,48 @@ void main() {
       ],
     );
   });
+
+  testWidgets('cancel does not save anything', (tester) async {
+    final helpers = FakeCalculatorHelpers();
+    final showSave = ValueNotifier<bool>(true);
+    final settingsRepo = FakeSettingsRepository(
+      initialSettings: GeneralSettingsModel.initial(),
+    );
+    final calculatorNotifier = FakeCalculatorNotifier(
+      initialState: CalculatorState(),
+    );
+
+    await tester.pumpApp(
+      SaveForm(
+        data: const CalculationResult(
+          electricity: 0,
+          filament: 0,
+          risk: 0,
+          labour: 0,
+          total: 0,
+        ),
+        showSave: showSave,
+      ),
+      [
+        calculatorProvider.overrideWith(() => calculatorNotifier),
+        settingsRepositoryProvider.overrideWithValue(settingsRepo),
+        printersRepositoryProvider.overrideWithValue(FakePrintersRepository()),
+        materialsRepositoryProvider.overrideWithValue(
+          FakeMaterialsRepository(),
+        ),
+        calculatorHelpersProvider.overrideWithValue(helpers),
+      ],
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('calculator.save.cancel.button')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(helpers.lastSavedPrint, isNull);
+    expect(showSave.value, isFalse);
+  });
 }
 
 class HistoryModelCapture {

--- a/test/database/repositories/entity_repository_crud_test.dart
+++ b/test/database/repositories/entity_repository_crud_test.dart
@@ -57,6 +57,30 @@ void main() {
     expect(await repo.getMaterials(), hasLength(1));
   });
 
+  test(
+    'materials repository maps legacy records with tracking disabled by default',
+    () async {
+      final repo = container.read(materialsRepositoryProvider);
+      await stringMapStoreFactory
+          .store('materials')
+          .record('material-legacy')
+          .put(db, {
+            'name': 'PLA',
+            'cost': '25',
+            'color': 'Red',
+            'weight': '1000',
+            'archived': false,
+          });
+
+      final material = await repo.getMaterialById('material-legacy');
+
+      expect(material, isNotNull);
+      expect(material!.autoDeductEnabled, isFalse);
+      expect(material.originalWeight, 1000);
+      expect(material.remainingWeight, 1000);
+    },
+  );
+
   test('materials repository updates and deletes records', () async {
     final repo = container.read(materialsRepositoryProvider);
     await stringMapStoreFactory.store('materials').record('material-1').put(

--- a/test/database/services/material_stock_service_test.dart
+++ b/test/database/services/material_stock_service_test.dart
@@ -1,0 +1,209 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:riverpod/riverpod.dart';
+import 'package:sembast/sembast_memory.dart';
+import 'package:threed_print_cost_calculator/core/logging/app_logger.dart';
+import 'package:threed_print_cost_calculator/database/repositories/materials_repository.dart';
+import 'package:threed_print_cost_calculator/database/services/material_stock_service.dart';
+import 'package:threed_print_cost_calculator/history/model/history_model.dart';
+import 'package:threed_print_cost_calculator/settings/model/material_model.dart';
+import 'package:threed_print_cost_calculator/shared/providers/app_providers.dart';
+
+class _NoopLogSink extends AppLogSink {
+  const _NoopLogSink();
+
+  @override
+  void log(AppLogEvent event) {}
+}
+
+void main() {
+  late Database db;
+  late ProviderContainer container;
+
+  setUp(() async {
+    db = await databaseFactoryMemory.openDatabase(
+      'material_stock_service_${DateTime.now().microsecondsSinceEpoch}.db',
+    );
+    container = ProviderContainer(
+      overrides: [
+        databaseProvider.overrideWithValue(db),
+        appLogSinkProvider.overrideWithValue(const _NoopLogSink()),
+        appLoggerConfigProvider.overrideWithValue(
+          const AppLoggerConfig(minLevel: AppLogLevel.debug),
+        ),
+      ],
+    );
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await db.close();
+  });
+
+  HistoryModel buildHistory(List<Map<String, dynamic>> usages) {
+    return HistoryModel(
+      name: 'Saved print',
+      totalCost: 1,
+      riskCost: 0,
+      filamentCost: 1,
+      electricityCost: 0,
+      labourCost: 0,
+      date: DateTime.parse('2024-01-01T00:00:00.000Z'),
+      printer: 'Printer',
+      material: 'Material',
+      weight: usages.fold<num>(
+        0,
+        (sum, usage) => sum + (usage['weightGrams'] as num),
+      ),
+      materialUsages: usages,
+      timeHours: '00:10',
+    );
+  }
+
+  test('deducts only tracked materials per usage row', () async {
+    final repo = container.read(materialsRepositoryProvider);
+    await stringMapStoreFactory
+        .store('materials')
+        .record('tracked')
+        .put(
+          db,
+          const MaterialModel(
+            id: 'tracked',
+            name: 'PLA',
+            cost: '20',
+            color: 'Black',
+            weight: '1000',
+            archived: false,
+            autoDeductEnabled: true,
+            originalWeight: 1000,
+            remainingWeight: 900,
+          ).toMap(),
+        );
+    await stringMapStoreFactory
+        .store('materials')
+        .record('untracked')
+        .put(
+          db,
+          const MaterialModel(
+            id: 'untracked',
+            name: 'ABS',
+            cost: '22',
+            color: 'White',
+            weight: '1000',
+            archived: false,
+            originalWeight: 1000,
+            remainingWeight: 1000,
+          ).toMap(),
+        );
+
+    await container
+        .read(materialStockServiceProvider)
+        .deductForSavedHistory(
+          buildHistory([
+            {
+              'materialId': 'tracked',
+              'materialName': 'PLA',
+              'costPerKg': 20,
+              'weightGrams': 125,
+            },
+            {
+              'materialId': 'untracked',
+              'materialName': 'ABS',
+              'costPerKg': 22,
+              'weightGrams': 75,
+            },
+          ]),
+        );
+
+    expect((await repo.getMaterialById('tracked'))!.remainingWeight, 775);
+    expect((await repo.getMaterialById('untracked'))!.remainingWeight, 1000);
+  });
+
+  test('deduction clamps at zero and repeated saves are cumulative', () async {
+    final repo = container.read(materialsRepositoryProvider);
+    await stringMapStoreFactory
+        .store('materials')
+        .record('tracked')
+        .put(
+          db,
+          const MaterialModel(
+            id: 'tracked',
+            name: 'PLA',
+            cost: '20',
+            color: 'Black',
+            weight: '1000',
+            archived: false,
+            autoDeductEnabled: true,
+            originalWeight: 1000,
+            remainingWeight: 150,
+          ).toMap(),
+        );
+
+    final service = container.read(materialStockServiceProvider);
+
+    await service.deductForSavedHistory(
+      buildHistory([
+        {
+          'materialId': 'tracked',
+          'materialName': 'PLA',
+          'costPerKg': 20,
+          'weightGrams': 80,
+        },
+      ]),
+    );
+    expect((await repo.getMaterialById('tracked'))!.remainingWeight, 70);
+
+    await service.deductForSavedHistory(
+      buildHistory([
+        {
+          'materialId': 'tracked',
+          'materialName': 'PLA',
+          'costPerKg': 20,
+          'weightGrams': 120,
+        },
+      ]),
+    );
+    expect((await repo.getMaterialById('tracked'))!.remainingWeight, 0);
+  });
+
+  test('multiple usage rows for same material are summed once', () async {
+    final repo = container.read(materialsRepositoryProvider);
+    await stringMapStoreFactory
+        .store('materials')
+        .record('tracked')
+        .put(
+          db,
+          const MaterialModel(
+            id: 'tracked',
+            name: 'PLA',
+            cost: '20',
+            color: 'Black',
+            weight: '1000',
+            archived: false,
+            autoDeductEnabled: true,
+            originalWeight: 1000,
+            remainingWeight: 500,
+          ).toMap(),
+        );
+
+    await container
+        .read(materialStockServiceProvider)
+        .deductForSavedHistory(
+          buildHistory([
+            {
+              'materialId': 'tracked',
+              'materialName': 'PLA',
+              'costPerKg': 20,
+              'weightGrams': 125,
+            },
+            {
+              'materialId': 'tracked',
+              'materialName': 'PLA',
+              'costPerKg': 20,
+              'weightGrams': 75,
+            },
+          ]),
+        );
+
+    expect((await repo.getMaterialById('tracked'))!.remainingWeight, 300);
+  });
+}

--- a/test/helpers/lower_level_test_fakes.dart
+++ b/test/helpers/lower_level_test_fakes.dart
@@ -101,7 +101,7 @@ class FakePrintersRepository implements PrintersRepository {
 
 class FakeMaterialsRepository implements MaterialsRepository {
   FakeMaterialsRepository([Map<String, MaterialModel>? materials])
-    : _materials = materials ?? const {};
+    : _materials = Map<String, MaterialModel>.from(materials ?? const {});
 
   final Map<String, MaterialModel> _materials;
 
@@ -121,8 +121,13 @@ class FakeMaterialsRepository implements MaterialsRepository {
   Future<MaterialModel?> getMaterialById(String id) async => _materials[id];
 
   @override
-  Future<Object?> saveMaterial(MaterialModel material, {String? id}) async =>
-      id ?? material.id;
+  Future<Object?> saveMaterial(MaterialModel material, {String? id}) async {
+    final key = id ?? material.id;
+    if (key.isNotEmpty) {
+      _materials[key] = material.copyWith(id: key);
+    }
+    return key;
+  }
 
   @override
   Future<void> deleteMaterial(String id) async {}

--- a/test/settings/materials/material_form_test.dart
+++ b/test/settings/materials/material_form_test.dart
@@ -70,6 +70,16 @@ void main() {
     await tester.enterText(_field('settings.materials.color.input'), 'Blue');
     await tester.enterText(_field('settings.materials.weight.input'), '1000');
     await tester.enterText(_field('settings.materials.cost.input'), '24.5');
+    await tester.tap(
+      find.byKey(
+        const ValueKey<String>('settings.materials.track_remaining.toggle'),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      _field('settings.materials.remaining_weight.input'),
+      '850',
+    );
 
     await tester.tap(
       find.byKey(const ValueKey<String>('settings.materials.save.button')),
@@ -82,9 +92,50 @@ void main() {
     expect(repo.savedMaterials.single.color, 'Blue');
     expect(repo.savedMaterials.single.weight, '1000');
     expect(repo.savedMaterials.single.cost, '24.5');
+    expect(repo.savedMaterials.single.autoDeductEnabled, isTrue);
+    expect(repo.savedMaterials.single.originalWeight, 1000);
+    expect(repo.savedMaterials.single.remainingWeight, 850);
     expect(repo.getMaterialByIdCalls, ['material-1']);
     expect(savedResult.single, isA<MaterialModel>());
     expect((savedResult.single as MaterialModel).id, 'material-1');
+  });
+
+  testWidgets('remaining filament input strips leading zeros', (tester) async {
+    final repo = FakeMaterialsRepository();
+    final db = await tester.pumpApp(
+      _MaterialDialogHost(
+        onResult: (_) {},
+        builder: (_) => const MaterialForm(),
+      ),
+      [materialsRepositoryProvider.overrideWithValue(repo)],
+    );
+    addTearDown(db.close);
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(
+        const ValueKey<String>('settings.materials.track_remaining.toggle'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      _field('settings.materials.remaining_weight.input'),
+      '01000',
+    );
+    await tester.pump();
+
+    expect(
+      tester
+          .widget<TextFormField>(
+            _field('settings.materials.remaining_weight.input'),
+          )
+          .controller!
+          .text,
+      '1000',
+    );
   });
 
   testWidgets('null save results close the dialog safely', (tester) async {
@@ -125,6 +176,9 @@ void main() {
       color: 'Red',
       weight: '1000',
       archived: false,
+      autoDeductEnabled: true,
+      originalWeight: 1000,
+      remainingWeight: 725,
     );
     final repo = FakeMaterialsRepository();
     repo.materialsById[material.id] = material;
@@ -169,6 +223,27 @@ void main() {
           .controller!
           .text,
       '24.5',
+    );
+    expect(
+      tester
+          .widget<SwitchListTile>(
+            find.byKey(
+              const ValueKey<String>(
+                'settings.materials.track_remaining.toggle',
+              ),
+            ),
+          )
+          .value,
+      isTrue,
+    );
+    expect(
+      tester
+          .widget<TextFormField>(
+            _field('settings.materials.remaining_weight.input'),
+          )
+          .controller!
+          .text,
+      '725.0',
     );
 
     await tester.enterText(

--- a/test/settings/materials/materials_test.dart
+++ b/test/settings/materials/materials_test.dart
@@ -24,6 +24,9 @@ MaterialModel _material() {
     color: 'Red',
     weight: '1000',
     archived: false,
+    autoDeductEnabled: true,
+    originalWeight: 1000,
+    remainingWeight: 800,
   );
 }
 
@@ -93,6 +96,7 @@ void main() {
     expect(find.text('Red'), findsOneWidget);
     expect(find.text('24.5'), findsOneWidget);
     expect(find.text('1000${S.current.gramsSuffix}'), findsOneWidget);
+    expect(find.text('Remaining: 800${S.current.gramsSuffix}'), findsOneWidget);
   });
 
   testWidgets('retries after a stream error', (tester) async {

--- a/test/settings/providers/materials_notifier_test.dart
+++ b/test/settings/providers/materials_notifier_test.dart
@@ -1,6 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:riverpod/riverpod.dart';
+import 'package:threed_print_cost_calculator/database/repositories/materials_repository.dart';
+import 'package:threed_print_cost_calculator/settings/model/material_model.dart';
 import 'package:threed_print_cost_calculator/settings/providers/materials_notifier.dart';
+
+import '../settings_test_fakes.dart';
 
 void main() {
   group('MaterialsProvider localized parsing', () {
@@ -33,5 +37,91 @@ void main() {
       expect(state.cost.value, 0);
       expect(state.weight.value, 0);
     });
+
+    test(
+      'enabling tracking later seeds remaining weight from current spool',
+      () async {
+        final materialsRepository = FakeMaterialsRepository();
+        final seededContainer = ProviderContainer(
+          overrides: [
+            materialsRepositoryProvider.overrideWithValue(materialsRepository),
+          ],
+        );
+        addTearDown(seededContainer.dispose);
+
+        await materialsRepository.saveMaterial(
+          const MaterialModel(
+            id: 'mat-1',
+            name: 'PLA',
+            cost: '20',
+            color: 'Red',
+            weight: '1000',
+            archived: false,
+            originalWeight: 1000,
+            remainingWeight: 1000,
+          ),
+          id: 'mat-1',
+        );
+
+        final seededNotifier = seededContainer.read(materialsProvider.notifier);
+        seededNotifier.init('mat-1');
+        await Future<void>.delayed(Duration.zero);
+        seededNotifier.updateWeight('750');
+        await seededNotifier.submit('mat-1');
+
+        final disabledSaved = materialsRepository.savedMaterials.last;
+        expect(disabledSaved.autoDeductEnabled, isFalse);
+        expect(disabledSaved.remainingWeight, 750);
+
+        seededNotifier.init('mat-1');
+        await Future<void>.delayed(Duration.zero);
+        seededNotifier.updateAutoDeductEnabled(true);
+        await seededNotifier.submit('mat-1');
+
+        final enabledSaved = materialsRepository.savedMaterials.last;
+        expect(enabledSaved.autoDeductEnabled, isTrue);
+        expect(enabledSaved.originalWeight, 750);
+        expect(enabledSaved.remainingWeight, 750);
+      },
+    );
+
+    test(
+      'editing weight then enabling tracking in same session uses edited spool weight',
+      () async {
+        final materialsRepository = FakeMaterialsRepository();
+        final seededContainer = ProviderContainer(
+          overrides: [
+            materialsRepositoryProvider.overrideWithValue(materialsRepository),
+          ],
+        );
+        addTearDown(seededContainer.dispose);
+
+        await materialsRepository.saveMaterial(
+          const MaterialModel(
+            id: 'mat-2',
+            name: 'PETG',
+            cost: '25',
+            color: 'Blue',
+            weight: '1000',
+            archived: false,
+            originalWeight: 1000,
+            remainingWeight: 1000,
+          ),
+          id: 'mat-2',
+        );
+
+        final seededNotifier = seededContainer.read(materialsProvider.notifier);
+        seededNotifier.init('mat-2');
+        await Future<void>.delayed(Duration.zero);
+        seededNotifier.updateWeight('750');
+        seededNotifier.updateAutoDeductEnabled(true);
+        await seededNotifier.submit('mat-2');
+
+        final saved = materialsRepository.savedMaterials.last;
+        expect(saved.autoDeductEnabled, isTrue);
+        expect(saved.originalWeight, 750);
+        expect(saved.remainingWeight, 750);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
- add shared promo visibility state in `lib/shared/providers/pro_promotion_visibility.dart` and wire settings so free users can hide Pro previews without changing entitlement gating
- render passive locked premium breakdown rows in `lib/calculator/view/calculator_results.dart` when `shouldShowProPromotionProvider` is true, limited to calculator results only
- add focused coverage for promo visibility state, settings toggle behavior, and calculator promo row rendering/totals

## Verification
- `fvm flutter analyze`
- `fvm flutter test test/calculator/view/calculator_results_test.dart test/calculator/view/calculator_page_lower_level_test.dart`
- `fvm flutter test test/shared/providers/pro_promotion_visibility_test.dart test/settings/general_settings_form_test.dart test/settings/settings_page_test.dart test/app/view/app_page_test.dart test/app/view/app_test.dart test/app/view/premium_gating_test.dart test/calculator/view/calculator_page_test.dart test/calculator/view/calculator_page_lower_level_test.dart test/calculator/view/calculator_results_test.dart`
- `make flutter_test` *(currently fails on pre-existing `test/calculator/helpers/calculator_helpers_test.dart` localization assertions unrelated to this change)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Material weight tracking with automatic deduction when saving prints
  * Hide Pro feature promotions toggle for free users to reduce upgrade prompts
  * Improved numeric input handling with automatic leading-zero normalization
  * Expanded localization support with error messages and save confirmations across 10 languages

* **Documentation**
  * Updated development workflow and project architecture guidance

* **Chores**
  * Simplified VS Code launch configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->