### PR TITLE
docs(crashlytics): mark b912ac41 libflutter.so regression in 2.9.4

### DIFF
--- a/docs/issues/b912ac41d193161e542d238bcb065645.md
+++ b/docs/issues/b912ac41d193161e542d238bcb065645.md
@@ -1,16 +1,16 @@
 # Crashlytics: libflutter.so missing
 
-Status: fixed
+Status: investigating
 Investigation started: 2026-05-06 04:56 AM by Hermes Agent
 Source: Firebase Crashlytics
 Crashlytics issue ID: b912ac41d193161e542d238bcb065645
 First seen: 2.8.0
-Last seen: 2.9.3
-Affected versions: 2.8.0 - 2.9.1
-Affected users: 6
+Last seen: 2.9.4
+Affected versions: 2.8.0 - 2.9.1, regressed in 2.9.4
+Affected users: 8 (16 events)
 Severity: blocker
 Type: crash (fatal)
-Priority: high — crash at app launch on core flow, fatal (cannot recover)
+Priority: critical — SIGNAL_REGRESSED + SIGNAL_EARLY
 
 [View in Firebase Console](https://console.firebase.google.com/project/d-print-cost-calculator-cf650/crashlytics/app/android:com.threed_print_calculator/issues/b912ac41d193161e542d238bcb065645)
 
@@ -95,3 +95,16 @@ This configuration ensures that the correct native libraries are packaged for th
 ## Follow-up
 - Monitor Crashlytics after next release (2.9.4+) to confirm crash stops occurring.
 - Consider removing the entire `splits` block (currently commented out) in a future cleanup PR.
+
+## Regression (2026-05-10)
+The crash REGRESSED in version 2.9.4 despite the previous fix (PR #47, merged May 9, 2026).
+- Regressed: 2026-05-10 in version 2.9.4 (191)
+- Signal: SIGNAL_REGRESSED
+- Signal: SIGNAL_EARLY (100% crashes in first second of session)
+- Impact: 16 events, 8 impacted users (up from 6)
+- Previous fix claimed the `splits` block was commented out and `ndk abiFilters` were set — but the issue recurred, meaning the configuration fix was either not fully applied or a new trigger appeared.
+
+Previous Kanban task `t_6ff0b649` was set to `blocked` but the regression branch was never committed/pushed and no actual fix work was done. This triage cycle creates a fresh task.
+
+## Resolution (PENDING — this regression cycle)
+TBD

--- a/docs/issues/b912ac41d193161e542d238bcb065645.md
+++ b/docs/issues/b912ac41d193161e542d238bcb065645.md
@@ -1,5 +1,6 @@
 # Crashlytics: libflutter.so missing
 
+ClickUp Task: t_6ff0b649
 Status: investigating
 Investigation started: 2026-05-06 04:56 AM by Hermes Agent
 Source: Firebase Crashlytics
@@ -51,7 +52,7 @@ io.flutter.embedding.android.FlutterActivity.onCreate
 - Firebase issue state: `OPEN`
 - Signal: `SIGNAL_EARLY` (100% of crashes happen in first second of session)
 - Signal: `SIGNAL_FRESH` (First appeared 7 days ago)
-- Impacted users: 6
+- Impacted users: 8 (16 events)
 
 ## Enrichment notes (from Flutter issue #180192 & community)
 - Recurring issue across many Flutter apps on Google Play


### PR DESCRIPTION
## Summary
Updates the Crashlytics issue doc for b912ac41d193161e542d238bcb065645 to reflect its regression in version 2.9.4 (build 191).

## Changes
- Status: updated from `fixed` to `investigating`
- Last seen: updated from 2.9.3 to 2.9.4
- Affected users: updated from 6 to 8 (16 events)
- Added regression section documenting the recurrence on May 10, 2026

## Context
This crash (libflutter.so missing on Android) was previously marked fixed in PR #47 (merged May 9, 2026) but regressed the following day in 2.9.4. A new Kanban task has been queued for the resolver to investigate and implement a proper fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated critical regression report for version 2.9.4, escalating the issue to blocker status with critical priority designation and enhanced signal tracking including early detection markers
* Documented that a previously reported crash fix did not fully resolve the underlying regression, which has now recurred in the latest build

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RemeJuan/threed_print_cost_calculator/pull/55)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->