### PR TITLE
refactor(history): split HistoryItem into focused sibling widgets

### DIFF
--- a/docs/issues/b912ac41d193161e542d238bcb065645.md
+++ b/docs/issues/b912ac41d193161e542d238bcb065645.md
@@ -1,16 +1,16 @@
 # Crashlytics: libflutter.so missing
 
-Status: fixed
+Status: investigating
 Investigation started: 2026-05-06 04:56 AM by Hermes Agent
 Source: Firebase Crashlytics
 Crashlytics issue ID: b912ac41d193161e542d238bcb065645
 First seen: 2.8.0
-Last seen: 2.9.3
-Affected versions: 2.8.0 - 2.9.1
-Affected users: 6
+Last seen: 2.9.4
+Affected versions: 2.8.0 - 2.9.1, regressed in 2.9.4
+Affected users: 8 (16 events)
 Severity: blocker
 Type: crash (fatal)
-Priority: high — crash at app launch on core flow, fatal (cannot recover)
+Priority: critical — SIGNAL_REGRESSED + SIGNAL_EARLY
 
 [View in Firebase Console](https://console.firebase.google.com/project/d-print-cost-calculator-cf650/crashlytics/app/android:com.threed_print_calculator/issues/b912ac41d193161e542d238bcb065645)
 
@@ -95,3 +95,16 @@ This configuration ensures that the correct native libraries are packaged for th
 ## Follow-up
 - Monitor Crashlytics after next release (2.9.4+) to confirm crash stops occurring.
 - Consider removing the entire `splits` block (currently commented out) in a future cleanup PR.
+
+## Regression (2026-05-10)
+The crash REGRESSED in version 2.9.4 despite the previous fix (PR #47, merged May 9, 2026).
+- Regressed: 2026-05-10 in version 2.9.4 (191)
+- Signal: SIGNAL_REGRESSED
+- Signal: SIGNAL_EARLY (100% crashes in first second of session)
+- Impact: 16 events, 8 impacted users (up from 6)
+- Previous fix claimed the `splits` block was commented out and `ndk abiFilters` were set — but the issue recurred, meaning the configuration fix was either not fully applied or a new trigger appeared.
+
+Previous Kanban task `t_6ff0b649` was set to `blocked` but the regression branch was never committed/pushed and no actual fix work was done. This triage cycle creates a fresh task.
+
+## Resolution (PENDING — this regression cycle)
+TBD

--- a/lib/history/components/history_item.dart
+++ b/lib/history/components/history_item.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:intl/intl.dart';
-import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
-import 'package:threed_print_cost_calculator/history/model/history_model.dart';
 import 'package:threed_print_cost_calculator/calculator/view/components/materials_selection/materials_providers.dart';
 import 'package:threed_print_cost_calculator/history/components/history_item_actions.dart';
+import 'package:threed_print_cost_calculator/history/components/history_item_cost_rows.dart';
+import 'package:threed_print_cost_calculator/history/components/history_item_header.dart';
+import 'package:threed_print_cost_calculator/history/components/history_item_material_breakdown.dart';
+import 'package:threed_print_cost_calculator/history/components/history_item_slidable_wrapper.dart';
+import 'package:threed_print_cost_calculator/history/components/history_item_summary.dart';
+import 'package:threed_print_cost_calculator/history/model/history_model.dart';
+import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
 import 'package:threed_print_cost_calculator/shared/utils/csv_utils.dart';
 
 class HistoryItem extends HookConsumerWidget {
@@ -39,298 +42,43 @@ class HistoryItem extends HookConsumerWidget {
       exportCsv: exportCsv,
     );
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      child: Slidable(
-        key: ValueKey(dbKey),
-        endActionPane: ActionPane(
-          motion: const ScrollMotion(),
-          extentRatio: 0.3,
-          children: [
-            const SizedBox(width: 12),
-            CustomSlidableAction(
-              flex: 1,
-              onPressed: (_) async =>
-                  actionsController.deleteEntry(context, ref),
-              backgroundColor: Colors.red,
-              foregroundColor: Colors.white,
-              padding: EdgeInsets.zero,
-              borderRadius: BorderRadius.circular(8),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(vertical: 8),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    const Icon(Icons.delete, size: 20, color: Colors.white),
-                    const SizedBox(height: 4),
-                    Text(
-                      l10n.deleteButton,
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 11,
-                        fontWeight: FontWeight.w600,
-                      ),
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ],
-                ),
-              ),
-            ),
-            const SizedBox(width: 12),
-          ],
+    return HistoryItemSlidableWrapper(
+      dbKey: dbKey,
+      deleteLabel: l10n.deleteButton,
+      onDelete: () => actionsController.deleteEntry(context, ref),
+      child: Container(
+        key: ValueKey<String>('$itemKeyPrefix.card'),
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+          color: const Color.fromRGBO(8, 8, 18, 1),
+          borderRadius: BorderRadius.circular(8),
         ),
-        child: Container(
-          key: ValueKey<String>('$itemKeyPrefix.card'),
-          padding: const EdgeInsets.all(8),
-          decoration: BoxDecoration(
-            color: const Color.fromRGBO(8, 8, 18, 1),
-            borderRadius: BorderRadius.circular(8),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Text(
-                    key: ValueKey<String>('$itemKeyPrefix.name'),
-                    data.name,
-                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      color: Colors.white,
-                      fontWeight: FontWeight.w800,
-                    ),
-                  ),
-                  const Spacer(),
-                  HistoryItemActions(
-                    dbKey: dbKey,
-                    data: data,
-                    itemKeyPrefix: itemKeyPrefix,
-                    onHistoryLoaded: onHistoryLoaded,
-                    onOverflowMenuOpened: onOverflowMenuOpened,
-                    deleteHistoryEntry: deleteHistoryEntry,
-                    exportCsv: exportCsv,
-                  ),
-                  Text(
-                    DateFormat('dd MMM yyyy').format(data.date),
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: Colors.white,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            HistoryItemHeader(
+              dbKey: dbKey,
+              data: data,
+              itemKeyPrefix: itemKeyPrefix,
+              onHistoryLoaded: onHistoryLoaded,
+              onOverflowMenuOpened: onOverflowMenuOpened,
+              deleteHistoryEntry: deleteHistoryEntry,
+              exportCsv: exportCsv,
+            ),
+            const SizedBox(height: 8),
+            HistoryItemCostRows(data: data, itemKeyPrefix: itemKeyPrefix),
+            const SizedBox(height: 4),
+            const Divider(),
+            const SizedBox(height: 4),
+            HistoryItemSummary(data: data, itemKeyPrefix: itemKeyPrefix),
+            if (data.materialUsages.isNotEmpty)
+              HistoryItemMaterialBreakdown(
+                materialUsages: data.materialUsages,
+                materialsById: materialsById,
               ),
-              const SizedBox(height: 8),
-              _row(
-                context,
-                l10n.electricityCostLabel,
-                data.electricityCost,
-                key: ValueKey<String>('$itemKeyPrefix.electricityCost'),
-              ),
-              _row(
-                context,
-                l10n.filamentCostLabel,
-                data.filamentCost,
-                key: ValueKey<String>('$itemKeyPrefix.filamentCost'),
-              ),
-              _row(
-                context,
-                l10n.labourCostLabel,
-                data.labourCost,
-                key: ValueKey<String>('$itemKeyPrefix.labourCost'),
-              ),
-              _row(
-                context,
-                l10n.riskCostLabel,
-                data.riskCost,
-                key: ValueKey<String>('$itemKeyPrefix.riskCost'),
-              ),
-              const SizedBox(height: 4),
-              Divider(),
-              const SizedBox(height: 4),
-              Row(
-                children: [
-                  Text(
-                    l10n.totalCostLabel,
-                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      color: Colors.white,
-                      fontWeight: FontWeight.w800,
-                    ),
-                  ),
-                  const Spacer(),
-                  Text(
-                    key: ValueKey<String>('$itemKeyPrefix.totalCost'),
-                    data.totalCost.toStringAsFixed(2),
-                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      color: Colors.white,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 8),
-              // Additional summary line: weight (kg) • time (e.g. 6h 20m) • printer • material
-              Builder(
-                builder: (context) {
-                  final weightKg = (data.weight / 1000);
-                  // parse timeHours which should be in "hh:mm" format
-                  String timeLabel;
-                  try {
-                    final parts = data.timeHours.split(':');
-                    final h = int.tryParse(parts[0]) ?? 0;
-                    final m =
-                        int.tryParse(parts.length > 1 ? parts[1] : '0') ?? 0;
-                    timeLabel = '${h}h ${m}m';
-                  } catch (_) {
-                    timeLabel = data.timeHours;
-                  }
-
-                  final summary =
-                      '${weightKg.toStringAsFixed(2)} kg • $timeLabel • ${data.printer} • ${data.material}';
-
-                  return Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        key: ValueKey<String>('$itemKeyPrefix.summary'),
-                        summary,
-                        style: Theme.of(context).textTheme.bodySmall,
-                      ),
-                      if (data.materialUsages.isNotEmpty) ...[
-                        const SizedBox(height: 8),
-                        // Small accordion for material breakdown. Constrain height so
-                        // long lists remain scrollable and don't expand the history item.
-                        Theme(
-                          data: Theme.of(
-                            context,
-                          ).copyWith(dividerColor: Colors.transparent),
-                          child: ExpansionTile(
-                            // Minimal padding so the tile aligns with surrounding content
-                            tilePadding: EdgeInsets.zero,
-                            childrenPadding: EdgeInsets.zero,
-                            backgroundColor: Colors.transparent,
-                            collapsedBackgroundColor: Colors.transparent,
-                            // Make chevron visible on dark background
-                            iconColor: Colors.white70,
-                            collapsedIconColor: Colors.white54,
-                            title: Text(
-                              l10n.materialBreakdownLabel,
-                              style: Theme.of(context).textTheme.bodyMedium
-                                  ?.copyWith(color: Colors.white70),
-                            ),
-                            children: [
-                              SingleChildScrollView(
-                                padding: EdgeInsets.zero,
-                                child: Column(
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: List.generate(
-                                    data.materialUsages.length,
-                                    (idx) {
-                                      final usage = data.materialUsages[idx];
-                                      final weight =
-                                          int.tryParse(
-                                            usage['weightGrams'].toString(),
-                                          ) ??
-                                          0;
-
-                                      String materialLabel;
-                                      final materialId = usage['materialId']
-                                          ?.toString();
-                                      if (materialId != null &&
-                                          materialsById.containsKey(
-                                            materialId,
-                                          )) {
-                                        final mat = materialsById[materialId]!;
-                                        materialLabel =
-                                            '${mat.name} (${mat.color})';
-                                      } else {
-                                        materialLabel =
-                                            usage['materialName']?.toString() ??
-                                            materialId ??
-                                            l10n.materialFallback;
-                                      }
-
-                                      return Column(
-                                        children: [
-                                          Padding(
-                                            padding: const EdgeInsets.symmetric(
-                                              vertical: 6,
-                                            ),
-                                            child: Row(
-                                              mainAxisAlignment:
-                                                  MainAxisAlignment
-                                                      .spaceBetween,
-                                              children: [
-                                                Expanded(
-                                                  child: Text(
-                                                    materialLabel,
-                                                    style: Theme.of(context)
-                                                        .textTheme
-                                                        .bodySmall
-                                                        ?.copyWith(
-                                                          color: Colors.white70,
-                                                        ),
-                                                  ),
-                                                ),
-                                                const SizedBox(width: 8),
-                                                Text(
-                                                  '${weight}g',
-                                                  style: Theme.of(context)
-                                                      .textTheme
-                                                      .bodySmall
-                                                      ?.copyWith(
-                                                        color: Colors.white60,
-                                                      ),
-                                                ),
-                                              ],
-                                            ),
-                                          ),
-                                          if (idx <
-                                              data.materialUsages.length - 1)
-                                            const Divider(
-                                              height: 1,
-                                              color: Colors.white12,
-                                            ),
-                                        ],
-                                      );
-                                    },
-                                  ),
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                      ],
-                    ],
-                  );
-                },
-              ),
-            ],
-          ),
+          ],
         ),
       ),
     );
   }
-}
-
-Widget _row(BuildContext context, String label, num value, {Key? key}) {
-  return Container(
-    padding: const EdgeInsets.symmetric(vertical: 6),
-    child: Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        Text(
-          label,
-          style: Theme.of(
-            context,
-          ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w700),
-        ),
-        Text(
-          key: key,
-          value.toStringAsFixed(2),
-          style: Theme.of(
-            context,
-          ).textTheme.bodyMedium?.copyWith(color: Colors.white),
-        ),
-      ],
-    ),
-  );
 }

--- a/lib/history/components/history_item_cost_rows.dart
+++ b/lib/history/components/history_item_cost_rows.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:threed_print_cost_calculator/history/model/history_model.dart';
+import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
+
+class HistoryItemCostRows extends StatelessWidget {
+  const HistoryItemCostRows({
+    required this.data,
+    required this.itemKeyPrefix,
+    super.key,
+  });
+
+  final HistoryModel data;
+  final String itemKeyPrefix;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Column(
+      children: [
+        _costRow(
+          context,
+          l10n.electricityCostLabel,
+          data.electricityCost,
+          key: ValueKey<String>('$itemKeyPrefix.electricityCost'),
+        ),
+        _costRow(
+          context,
+          l10n.filamentCostLabel,
+          data.filamentCost,
+          key: ValueKey<String>('$itemKeyPrefix.filamentCost'),
+        ),
+        _costRow(
+          context,
+          l10n.labourCostLabel,
+          data.labourCost,
+          key: ValueKey<String>('$itemKeyPrefix.labourCost'),
+        ),
+        _costRow(
+          context,
+          l10n.riskCostLabel,
+          data.riskCost,
+          key: ValueKey<String>('$itemKeyPrefix.riskCost'),
+        ),
+      ],
+    );
+  }
+}
+
+Widget _costRow(BuildContext context, String label, num value, {Key? key}) {
+  return Container(
+    padding: const EdgeInsets.symmetric(vertical: 6),
+    child: Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          label,
+          style: Theme.of(
+            context,
+          ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w700),
+        ),
+        Text(
+          key: key,
+          value.toStringAsFixed(2),
+          style: Theme.of(
+            context,
+          ).textTheme.bodyMedium?.copyWith(color: Colors.white),
+        ),
+      ],
+    ),
+  );
+}

--- a/lib/history/components/history_item_header.dart
+++ b/lib/history/components/history_item_header.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:threed_print_cost_calculator/history/components/history_item_actions.dart';
+import 'package:threed_print_cost_calculator/history/model/history_model.dart';
+import 'package:threed_print_cost_calculator/shared/utils/csv_utils.dart';
+
+class HistoryItemHeader extends StatelessWidget {
+  const HistoryItemHeader({
+    required this.dbKey,
+    required this.data,
+    required this.itemKeyPrefix,
+    this.onHistoryLoaded,
+    this.onOverflowMenuOpened,
+    this.deleteHistoryEntry,
+    this.exportCsv = exportCSVFile,
+    super.key,
+  });
+
+  final String dbKey;
+  final HistoryModel data;
+  final String itemKeyPrefix;
+  final Future<void> Function()? onHistoryLoaded;
+  final VoidCallback? onOverflowMenuOpened;
+  final Future<void> Function(WidgetRef ref, String dbKey)? deleteHistoryEntry;
+  final HistoryItemExportCsv exportCsv;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Text(
+          key: ValueKey<String>('$itemKeyPrefix.name'),
+          data.name,
+          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+            color: Colors.white,
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+        const Spacer(),
+        HistoryItemActions(
+          dbKey: dbKey,
+          data: data,
+          itemKeyPrefix: itemKeyPrefix,
+          onHistoryLoaded: onHistoryLoaded,
+          onOverflowMenuOpened: onOverflowMenuOpened,
+          deleteHistoryEntry: deleteHistoryEntry,
+          exportCsv: exportCsv,
+        ),
+        Text(
+          DateFormat('dd MMM yyyy').format(data.date),
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+            color: Colors.white,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/history/components/history_item_material_breakdown.dart
+++ b/lib/history/components/history_item_material_breakdown.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
+import 'package:threed_print_cost_calculator/settings/model/material_model.dart';
+
+class HistoryItemMaterialBreakdown extends StatelessWidget {
+  const HistoryItemMaterialBreakdown({
+    required this.materialUsages,
+    required this.materialsById,
+    super.key,
+  });
+
+  final List<Map<String, dynamic>> materialUsages;
+  final Map<String, MaterialModel> materialsById;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    return Theme(
+      data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+      child: ExpansionTile(
+        tilePadding: EdgeInsets.zero,
+        childrenPadding: EdgeInsets.zero,
+        backgroundColor: Colors.transparent,
+        collapsedBackgroundColor: Colors.transparent,
+        iconColor: Colors.white70,
+        collapsedIconColor: Colors.white54,
+        title: Text(
+          l10n.materialBreakdownLabel,
+          style: Theme.of(
+            context,
+          ).textTheme.bodyMedium?.copyWith(color: Colors.white70),
+        ),
+        children: [
+          SingleChildScrollView(
+            padding: EdgeInsets.zero,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: List.generate(materialUsages.length, (idx) {
+                final usage = materialUsages[idx];
+                final weight =
+                    int.tryParse(usage['weightGrams'].toString()) ?? 0;
+
+                String materialLabel;
+                final materialId = usage['materialId']?.toString();
+                if (materialId != null &&
+                    materialsById.containsKey(materialId)) {
+                  final mat = materialsById[materialId]!;
+                  materialLabel = '${mat.name} (${mat.color})';
+                } else {
+                  materialLabel =
+                      usage['materialName']?.toString() ??
+                      materialId ??
+                      l10n.materialFallback;
+                }
+
+                return Column(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 6),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Expanded(
+                            child: Text(
+                              materialLabel,
+                              style: Theme.of(context).textTheme.bodySmall
+                                  ?.copyWith(color: Colors.white70),
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Text(
+                            '${weight}g',
+                            style: Theme.of(context).textTheme.bodySmall
+                                ?.copyWith(color: Colors.white60),
+                          ),
+                        ],
+                      ),
+                    ),
+                    if (idx < materialUsages.length - 1)
+                      const Divider(height: 1, color: Colors.white12),
+                  ],
+                );
+              }),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/history/components/history_item_slidable_wrapper.dart
+++ b/lib/history/components/history_item_slidable_wrapper.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
+
+class HistoryItemSlidableWrapper extends StatelessWidget {
+  const HistoryItemSlidableWrapper({
+    required this.dbKey,
+    required this.deleteLabel,
+    required this.onDelete,
+    required this.child,
+    super.key,
+  });
+
+  final String dbKey;
+  final String deleteLabel;
+  final Future<void> Function() onDelete;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: Slidable(
+        key: ValueKey(dbKey),
+        endActionPane: ActionPane(
+          motion: const ScrollMotion(),
+          extentRatio: 0.3,
+          children: [
+            const SizedBox(width: 12),
+            CustomSlidableAction(
+              flex: 1,
+              onPressed: (_) async => onDelete(),
+              backgroundColor: Colors.red,
+              foregroundColor: Colors.white,
+              padding: EdgeInsets.zero,
+              borderRadius: BorderRadius.circular(8),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(Icons.delete, size: 20, color: Colors.white),
+                    const SizedBox(height: 4),
+                    Text(
+                      deleteLabel,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 11,
+                        fontWeight: FontWeight.w600,
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+          ],
+        ),
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/history/components/history_item_summary.dart
+++ b/lib/history/components/history_item_summary.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:threed_print_cost_calculator/history/model/history_model.dart';
+import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
+
+class HistoryItemSummary extends StatelessWidget {
+  const HistoryItemSummary({
+    required this.data,
+    required this.itemKeyPrefix,
+    super.key,
+  });
+
+  final HistoryModel data;
+  final String itemKeyPrefix;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    final weightKg = (data.weight / 1000);
+    String timeLabel;
+    try {
+      final parts = data.timeHours.split(':');
+      final h = int.tryParse(parts[0]) ?? 0;
+      final m = int.tryParse(parts.length > 1 ? parts[1] : '0') ?? 0;
+      timeLabel = '${h}h ${m}m';
+    } catch (_) {
+      timeLabel = data.timeHours;
+    }
+
+    final summary =
+        '${weightKg.toStringAsFixed(2)} kg • $timeLabel • ${data.printer} • ${data.material}';
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Text(
+              l10n.totalCostLabel,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                color: Colors.white,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            const Spacer(),
+            Text(
+              key: ValueKey<String>('$itemKeyPrefix.totalCost'),
+              data.totalCost.toStringAsFixed(2),
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                color: Colors.white,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Text(
+          key: ValueKey<String>('$itemKeyPrefix.summary'),
+          summary,
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Extracts slidable wrapper, header, cost rows, summary, and material breakdown into separate widgets under `lib/history/components/`
- No UI or behavior changes
- All 365 tests pass, analyze clean

Closes CU-86c9qf1v8