### PR TITLE
refactor: centralize formatWeight helper and debounce constants

### DIFF
--- a/docs/issues/b912ac41d193161e542d238bcb065645.md
+++ b/docs/issues/b912ac41d193161e542d238bcb065645.md
@@ -1,16 +1,16 @@
 # Crashlytics: libflutter.so missing
 
-Status: fixed
+Status: investigating
 Investigation started: 2026-05-06 04:56 AM by Hermes Agent
 Source: Firebase Crashlytics
 Crashlytics issue ID: b912ac41d193161e542d238bcb065645
 First seen: 2.8.0
-Last seen: 2.9.3
-Affected versions: 2.8.0 - 2.9.1
-Affected users: 6
+Last seen: 2.9.4
+Affected versions: 2.8.0 - 2.9.1, regressed in 2.9.4
+Affected users: 8 (16 events)
 Severity: blocker
 Type: crash (fatal)
-Priority: high — crash at app launch on core flow, fatal (cannot recover)
+Priority: critical — SIGNAL_REGRESSED + SIGNAL_EARLY
 
 [View in Firebase Console](https://console.firebase.google.com/project/d-print-cost-calculator-cf650/crashlytics/app/android:com.threed_print_calculator/issues/b912ac41d193161e542d238bcb065645)
 
@@ -95,3 +95,16 @@ This configuration ensures that the correct native libraries are packaged for th
 ## Follow-up
 - Monitor Crashlytics after next release (2.9.4+) to confirm crash stops occurring.
 - Consider removing the entire `splits` block (currently commented out) in a future cleanup PR.
+
+## Regression (2026-05-10)
+The crash REGRESSED in version 2.9.4 despite the previous fix (PR #47, merged May 9, 2026).
+- Regressed: 2026-05-10 in version 2.9.4 (191)
+- Signal: SIGNAL_REGRESSED
+- Signal: SIGNAL_EARLY (100% crashes in first second of session)
+- Impact: 16 events, 8 impacted users (up from 6)
+- Previous fix claimed the `splits` block was commented out and `ndk abiFilters` were set — but the issue recurred, meaning the configuration fix was either not fully applied or a new trigger appeared.
+
+Previous Kanban task `t_6ff0b649` was set to `blocked` but the regression branch was never committed/pushed and no actual fix work was done. This triage cycle creates a fresh task.
+
+## Resolution (PENDING — this regression cycle)
+TBD

--- a/lib/calculator/provider/calculator_notifier.dart
+++ b/lib/calculator/provider/calculator_notifier.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:riverpod/riverpod.dart';
+import 'package:threed_print_cost_calculator/shared/utils/debounce_constants.dart';
 import 'package:threed_print_cost_calculator/database/repositories/calculator_preferences_repository.dart';
 import 'package:threed_print_cost_calculator/calculator/helpers/calculator_helpers.dart';
 import 'package:threed_print_cost_calculator/calculator/model/material_usage_input.dart';
@@ -504,7 +505,7 @@ class CalculatorProvider extends Notifier<CalculatorState> {
   /// Schedule a debounced submit to avoid running heavy calculations on every keystroke.
   ///
   /// Cancels any previously scheduled submit and schedules a new one after [delay].
-  void submitDebounced({Duration delay = const Duration(milliseconds: 250)}) {
+  void submitDebounced({Duration delay = debounce250ms}) {
     _submitDebounce?.cancel();
     _submitDebounce = Timer(delay, submit);
   }

--- a/lib/calculator/view/components/materials_selection/material_row.dart
+++ b/lib/calculator/view/components/materials_selection/material_row.dart
@@ -7,6 +7,7 @@ import 'package:threed_print_cost_calculator/app/components/focus_safe_text_fiel
 import 'package:threed_print_cost_calculator/shared/constants.dart';
 import 'package:threed_print_cost_calculator/shared/utils/number_parsing.dart';
 import 'package:threed_print_cost_calculator/shared/utils/text_input_normalizers.dart';
+import 'package:threed_print_cost_calculator/shared/utils/weight_formatting.dart';
 
 /// Single material row used inside the materials list.
 ///
@@ -62,12 +63,6 @@ class _MaterialRowState extends State<MaterialRow> {
     final remainingWeight = widget.material?.remainingWeight ?? 0;
     final id = widget.usage.materialId.trim();
     final rowKey = id.isNotEmpty ? id : '__row_${widget.index}';
-
-    String formatWeight(num value) {
-      return value % 1 == 0
-          ? value.toStringAsFixed(0)
-          : value.toStringAsFixed(1);
-    }
 
     final isMaterialUnassigned =
         widget.usage.materialName.isEmpty ||

--- a/lib/calculator/view/material_select.dart
+++ b/lib/calculator/view/material_select.dart
@@ -6,6 +6,7 @@ import 'package:threed_print_cost_calculator/database/repositories/materials_rep
 import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
 import 'package:threed_print_cost_calculator/settings/model/general_settings_model.dart';
 import 'package:threed_print_cost_calculator/settings/services/settings_service.dart';
+import 'package:threed_print_cost_calculator/shared/utils/weight_formatting.dart';
 
 class MaterialSelect extends HookConsumerWidget {
   const MaterialSelect({super.key});
@@ -15,12 +16,6 @@ class MaterialSelect extends HookConsumerWidget {
     final loading = useState<bool>(true);
     final generalSettings = useState(GeneralSettingsModel.initial());
     final l10n = AppLocalizations.of(context)!;
-
-    String formatWeight(num value) {
-      return value % 1 == 0
-          ? value.toStringAsFixed(0)
-          : value.toStringAsFixed(1);
-    }
 
     Future<void> getSettings() async {
       generalSettings.value = await ref.read(settingsServiceProvider).get();

--- a/lib/history/components/history_item.dart
+++ b/lib/history/components/history_item.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:intl/intl.dart';
-import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
-import 'package:threed_print_cost_calculator/history/model/history_model.dart';
 import 'package:threed_print_cost_calculator/calculator/view/components/materials_selection/materials_providers.dart';
 import 'package:threed_print_cost_calculator/history/components/history_item_actions.dart';
+import 'package:threed_print_cost_calculator/history/components/history_item_cost_rows.dart';
+import 'package:threed_print_cost_calculator/history/components/history_item_header.dart';
+import 'package:threed_print_cost_calculator/history/components/history_item_material_breakdown.dart';
+import 'package:threed_print_cost_calculator/history/components/history_item_slidable_wrapper.dart';
+import 'package:threed_print_cost_calculator/history/components/history_item_summary.dart';
+import 'package:threed_print_cost_calculator/history/model/history_model.dart';
+import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
 import 'package:threed_print_cost_calculator/shared/utils/csv_utils.dart';
 
 class HistoryItem extends HookConsumerWidget {
@@ -39,298 +42,43 @@ class HistoryItem extends HookConsumerWidget {
       exportCsv: exportCsv,
     );
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      child: Slidable(
-        key: ValueKey(dbKey),
-        endActionPane: ActionPane(
-          motion: const ScrollMotion(),
-          extentRatio: 0.3,
-          children: [
-            const SizedBox(width: 12),
-            CustomSlidableAction(
-              flex: 1,
-              onPressed: (_) async =>
-                  actionsController.deleteEntry(context, ref),
-              backgroundColor: Colors.red,
-              foregroundColor: Colors.white,
-              padding: EdgeInsets.zero,
-              borderRadius: BorderRadius.circular(8),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(vertical: 8),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    const Icon(Icons.delete, size: 20, color: Colors.white),
-                    const SizedBox(height: 4),
-                    Text(
-                      l10n.deleteButton,
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 11,
-                        fontWeight: FontWeight.w600,
-                      ),
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ],
-                ),
-              ),
-            ),
-            const SizedBox(width: 12),
-          ],
+    return HistoryItemSlidableWrapper(
+      dbKey: dbKey,
+      deleteLabel: l10n.deleteButton,
+      onDelete: () => actionsController.deleteEntry(context, ref),
+      child: Container(
+        key: ValueKey<String>('$itemKeyPrefix.card'),
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+          color: const Color.fromRGBO(8, 8, 18, 1),
+          borderRadius: BorderRadius.circular(8),
         ),
-        child: Container(
-          key: ValueKey<String>('$itemKeyPrefix.card'),
-          padding: const EdgeInsets.all(8),
-          decoration: BoxDecoration(
-            color: const Color.fromRGBO(8, 8, 18, 1),
-            borderRadius: BorderRadius.circular(8),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Text(
-                    key: ValueKey<String>('$itemKeyPrefix.name'),
-                    data.name,
-                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      color: Colors.white,
-                      fontWeight: FontWeight.w800,
-                    ),
-                  ),
-                  const Spacer(),
-                  HistoryItemActions(
-                    dbKey: dbKey,
-                    data: data,
-                    itemKeyPrefix: itemKeyPrefix,
-                    onHistoryLoaded: onHistoryLoaded,
-                    onOverflowMenuOpened: onOverflowMenuOpened,
-                    deleteHistoryEntry: deleteHistoryEntry,
-                    exportCsv: exportCsv,
-                  ),
-                  Text(
-                    DateFormat('dd MMM yyyy').format(data.date),
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: Colors.white,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            HistoryItemHeader(
+              dbKey: dbKey,
+              data: data,
+              itemKeyPrefix: itemKeyPrefix,
+              onHistoryLoaded: onHistoryLoaded,
+              onOverflowMenuOpened: onOverflowMenuOpened,
+              deleteHistoryEntry: deleteHistoryEntry,
+              exportCsv: exportCsv,
+            ),
+            const SizedBox(height: 8),
+            HistoryItemCostRows(data: data, itemKeyPrefix: itemKeyPrefix),
+            const SizedBox(height: 4),
+            const Divider(),
+            const SizedBox(height: 4),
+            HistoryItemSummary(data: data, itemKeyPrefix: itemKeyPrefix),
+            if (data.materialUsages.isNotEmpty)
+              HistoryItemMaterialBreakdown(
+                materialUsages: data.materialUsages,
+                materialsById: materialsById,
               ),
-              const SizedBox(height: 8),
-              _row(
-                context,
-                l10n.electricityCostLabel,
-                data.electricityCost,
-                key: ValueKey<String>('$itemKeyPrefix.electricityCost'),
-              ),
-              _row(
-                context,
-                l10n.filamentCostLabel,
-                data.filamentCost,
-                key: ValueKey<String>('$itemKeyPrefix.filamentCost'),
-              ),
-              _row(
-                context,
-                l10n.labourCostLabel,
-                data.labourCost,
-                key: ValueKey<String>('$itemKeyPrefix.labourCost'),
-              ),
-              _row(
-                context,
-                l10n.riskCostLabel,
-                data.riskCost,
-                key: ValueKey<String>('$itemKeyPrefix.riskCost'),
-              ),
-              const SizedBox(height: 4),
-              Divider(),
-              const SizedBox(height: 4),
-              Row(
-                children: [
-                  Text(
-                    l10n.totalCostLabel,
-                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      color: Colors.white,
-                      fontWeight: FontWeight.w800,
-                    ),
-                  ),
-                  const Spacer(),
-                  Text(
-                    key: ValueKey<String>('$itemKeyPrefix.totalCost'),
-                    data.totalCost.toStringAsFixed(2),
-                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      color: Colors.white,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 8),
-              // Additional summary line: weight (kg) • time (e.g. 6h 20m) • printer • material
-              Builder(
-                builder: (context) {
-                  final weightKg = (data.weight / 1000);
-                  // parse timeHours which should be in "hh:mm" format
-                  String timeLabel;
-                  try {
-                    final parts = data.timeHours.split(':');
-                    final h = int.tryParse(parts[0]) ?? 0;
-                    final m =
-                        int.tryParse(parts.length > 1 ? parts[1] : '0') ?? 0;
-                    timeLabel = '${h}h ${m}m';
-                  } catch (_) {
-                    timeLabel = data.timeHours;
-                  }
-
-                  final summary =
-                      '${weightKg.toStringAsFixed(2)} kg • $timeLabel • ${data.printer} • ${data.material}';
-
-                  return Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        key: ValueKey<String>('$itemKeyPrefix.summary'),
-                        summary,
-                        style: Theme.of(context).textTheme.bodySmall,
-                      ),
-                      if (data.materialUsages.isNotEmpty) ...[
-                        const SizedBox(height: 8),
-                        // Small accordion for material breakdown. Constrain height so
-                        // long lists remain scrollable and don't expand the history item.
-                        Theme(
-                          data: Theme.of(
-                            context,
-                          ).copyWith(dividerColor: Colors.transparent),
-                          child: ExpansionTile(
-                            // Minimal padding so the tile aligns with surrounding content
-                            tilePadding: EdgeInsets.zero,
-                            childrenPadding: EdgeInsets.zero,
-                            backgroundColor: Colors.transparent,
-                            collapsedBackgroundColor: Colors.transparent,
-                            // Make chevron visible on dark background
-                            iconColor: Colors.white70,
-                            collapsedIconColor: Colors.white54,
-                            title: Text(
-                              l10n.materialBreakdownLabel,
-                              style: Theme.of(context).textTheme.bodyMedium
-                                  ?.copyWith(color: Colors.white70),
-                            ),
-                            children: [
-                              SingleChildScrollView(
-                                padding: EdgeInsets.zero,
-                                child: Column(
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: List.generate(
-                                    data.materialUsages.length,
-                                    (idx) {
-                                      final usage = data.materialUsages[idx];
-                                      final weight =
-                                          int.tryParse(
-                                            usage['weightGrams'].toString(),
-                                          ) ??
-                                          0;
-
-                                      String materialLabel;
-                                      final materialId = usage['materialId']
-                                          ?.toString();
-                                      if (materialId != null &&
-                                          materialsById.containsKey(
-                                            materialId,
-                                          )) {
-                                        final mat = materialsById[materialId]!;
-                                        materialLabel =
-                                            '${mat.name} (${mat.color})';
-                                      } else {
-                                        materialLabel =
-                                            usage['materialName']?.toString() ??
-                                            materialId ??
-                                            l10n.materialFallback;
-                                      }
-
-                                      return Column(
-                                        children: [
-                                          Padding(
-                                            padding: const EdgeInsets.symmetric(
-                                              vertical: 6,
-                                            ),
-                                            child: Row(
-                                              mainAxisAlignment:
-                                                  MainAxisAlignment
-                                                      .spaceBetween,
-                                              children: [
-                                                Expanded(
-                                                  child: Text(
-                                                    materialLabel,
-                                                    style: Theme.of(context)
-                                                        .textTheme
-                                                        .bodySmall
-                                                        ?.copyWith(
-                                                          color: Colors.white70,
-                                                        ),
-                                                  ),
-                                                ),
-                                                const SizedBox(width: 8),
-                                                Text(
-                                                  '${weight}g',
-                                                  style: Theme.of(context)
-                                                      .textTheme
-                                                      .bodySmall
-                                                      ?.copyWith(
-                                                        color: Colors.white60,
-                                                      ),
-                                                ),
-                                              ],
-                                            ),
-                                          ),
-                                          if (idx <
-                                              data.materialUsages.length - 1)
-                                            const Divider(
-                                              height: 1,
-                                              color: Colors.white12,
-                                            ),
-                                        ],
-                                      );
-                                    },
-                                  ),
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                      ],
-                    ],
-                  );
-                },
-              ),
-            ],
-          ),
+          ],
         ),
       ),
     );
   }
-}
-
-Widget _row(BuildContext context, String label, num value, {Key? key}) {
-  return Container(
-    padding: const EdgeInsets.symmetric(vertical: 6),
-    child: Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        Text(
-          label,
-          style: Theme.of(
-            context,
-          ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w700),
-        ),
-        Text(
-          key: key,
-          value.toStringAsFixed(2),
-          style: Theme.of(
-            context,
-          ).textTheme.bodyMedium?.copyWith(color: Colors.white),
-        ),
-      ],
-    ),
-  );
 }

--- a/lib/history/components/history_item_cost_rows.dart
+++ b/lib/history/components/history_item_cost_rows.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:threed_print_cost_calculator/history/model/history_model.dart';
+import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
+
+class HistoryItemCostRows extends StatelessWidget {
+  const HistoryItemCostRows({
+    required this.data,
+    required this.itemKeyPrefix,
+    super.key,
+  });
+
+  final HistoryModel data;
+  final String itemKeyPrefix;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Column(
+      children: [
+        _costRow(
+          context,
+          l10n.electricityCostLabel,
+          data.electricityCost,
+          key: ValueKey<String>('$itemKeyPrefix.electricityCost'),
+        ),
+        _costRow(
+          context,
+          l10n.filamentCostLabel,
+          data.filamentCost,
+          key: ValueKey<String>('$itemKeyPrefix.filamentCost'),
+        ),
+        _costRow(
+          context,
+          l10n.labourCostLabel,
+          data.labourCost,
+          key: ValueKey<String>('$itemKeyPrefix.labourCost'),
+        ),
+        _costRow(
+          context,
+          l10n.riskCostLabel,
+          data.riskCost,
+          key: ValueKey<String>('$itemKeyPrefix.riskCost'),
+        ),
+      ],
+    );
+  }
+}
+
+Widget _costRow(BuildContext context, String label, num value, {Key? key}) {
+  return Container(
+    padding: const EdgeInsets.symmetric(vertical: 6),
+    child: Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          label,
+          style: Theme.of(
+            context,
+          ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w700),
+        ),
+        Text(
+          key: key,
+          value.toStringAsFixed(2),
+          style: Theme.of(
+            context,
+          ).textTheme.bodyMedium?.copyWith(color: Colors.white),
+        ),
+      ],
+    ),
+  );
+}

--- a/lib/history/components/history_item_header.dart
+++ b/lib/history/components/history_item_header.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:threed_print_cost_calculator/history/components/history_item_actions.dart';
+import 'package:threed_print_cost_calculator/history/model/history_model.dart';
+import 'package:threed_print_cost_calculator/shared/utils/csv_utils.dart';
+
+class HistoryItemHeader extends StatelessWidget {
+  const HistoryItemHeader({
+    required this.dbKey,
+    required this.data,
+    required this.itemKeyPrefix,
+    this.onHistoryLoaded,
+    this.onOverflowMenuOpened,
+    this.deleteHistoryEntry,
+    this.exportCsv = exportCSVFile,
+    super.key,
+  });
+
+  final String dbKey;
+  final HistoryModel data;
+  final String itemKeyPrefix;
+  final Future<void> Function()? onHistoryLoaded;
+  final VoidCallback? onOverflowMenuOpened;
+  final Future<void> Function(WidgetRef ref, String dbKey)? deleteHistoryEntry;
+  final HistoryItemExportCsv exportCsv;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Text(
+          key: ValueKey<String>('$itemKeyPrefix.name'),
+          data.name,
+          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+            color: Colors.white,
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+        const Spacer(),
+        HistoryItemActions(
+          dbKey: dbKey,
+          data: data,
+          itemKeyPrefix: itemKeyPrefix,
+          onHistoryLoaded: onHistoryLoaded,
+          onOverflowMenuOpened: onOverflowMenuOpened,
+          deleteHistoryEntry: deleteHistoryEntry,
+          exportCsv: exportCsv,
+        ),
+        Text(
+          DateFormat('dd MMM yyyy').format(data.date),
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+            color: Colors.white,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/history/components/history_item_material_breakdown.dart
+++ b/lib/history/components/history_item_material_breakdown.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
+import 'package:threed_print_cost_calculator/settings/model/material_model.dart';
+
+class HistoryItemMaterialBreakdown extends StatelessWidget {
+  const HistoryItemMaterialBreakdown({
+    required this.materialUsages,
+    required this.materialsById,
+    super.key,
+  });
+
+  final List<Map<String, dynamic>> materialUsages;
+  final Map<String, MaterialModel> materialsById;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    return Theme(
+      data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+      child: ExpansionTile(
+        tilePadding: EdgeInsets.zero,
+        childrenPadding: EdgeInsets.zero,
+        backgroundColor: Colors.transparent,
+        collapsedBackgroundColor: Colors.transparent,
+        iconColor: Colors.white70,
+        collapsedIconColor: Colors.white54,
+        title: Text(
+          l10n.materialBreakdownLabel,
+          style: Theme.of(
+            context,
+          ).textTheme.bodyMedium?.copyWith(color: Colors.white70),
+        ),
+        children: [
+          SingleChildScrollView(
+            padding: EdgeInsets.zero,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: List.generate(materialUsages.length, (idx) {
+                final usage = materialUsages[idx];
+                final weight =
+                    int.tryParse(usage['weightGrams'].toString()) ?? 0;
+
+                String materialLabel;
+                final materialId = usage['materialId']?.toString();
+                if (materialId != null &&
+                    materialsById.containsKey(materialId)) {
+                  final mat = materialsById[materialId]!;
+                  materialLabel = '${mat.name} (${mat.color})';
+                } else {
+                  materialLabel =
+                      usage['materialName']?.toString() ??
+                      materialId ??
+                      l10n.materialFallback;
+                }
+
+                return Column(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 6),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Expanded(
+                            child: Text(
+                              materialLabel,
+                              style: Theme.of(context).textTheme.bodySmall
+                                  ?.copyWith(color: Colors.white70),
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Text(
+                            '${weight}g',
+                            style: Theme.of(context).textTheme.bodySmall
+                                ?.copyWith(color: Colors.white60),
+                          ),
+                        ],
+                      ),
+                    ),
+                    if (idx < materialUsages.length - 1)
+                      const Divider(height: 1, color: Colors.white12),
+                  ],
+                );
+              }),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/history/components/history_item_slidable_wrapper.dart
+++ b/lib/history/components/history_item_slidable_wrapper.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
+
+class HistoryItemSlidableWrapper extends StatelessWidget {
+  const HistoryItemSlidableWrapper({
+    required this.dbKey,
+    required this.deleteLabel,
+    required this.onDelete,
+    required this.child,
+    super.key,
+  });
+
+  final String dbKey;
+  final String deleteLabel;
+  final Future<void> Function() onDelete;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: Slidable(
+        key: ValueKey(dbKey),
+        endActionPane: ActionPane(
+          motion: const ScrollMotion(),
+          extentRatio: 0.3,
+          children: [
+            const SizedBox(width: 12),
+            CustomSlidableAction(
+              flex: 1,
+              onPressed: (_) async => onDelete(),
+              backgroundColor: Colors.red,
+              foregroundColor: Colors.white,
+              padding: EdgeInsets.zero,
+              borderRadius: BorderRadius.circular(8),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(Icons.delete, size: 20, color: Colors.white),
+                    const SizedBox(height: 4),
+                    Text(
+                      deleteLabel,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 11,
+                        fontWeight: FontWeight.w600,
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+          ],
+        ),
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/history/components/history_item_summary.dart
+++ b/lib/history/components/history_item_summary.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:threed_print_cost_calculator/history/model/history_model.dart';
+import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
+
+class HistoryItemSummary extends StatelessWidget {
+  const HistoryItemSummary({
+    required this.data,
+    required this.itemKeyPrefix,
+    super.key,
+  });
+
+  final HistoryModel data;
+  final String itemKeyPrefix;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    final weightKg = (data.weight / 1000);
+    String timeLabel;
+    try {
+      final parts = data.timeHours.split(':');
+      final h = int.tryParse(parts[0]) ?? 0;
+      final m = int.tryParse(parts.length > 1 ? parts[1] : '0') ?? 0;
+      timeLabel = '${h}h ${m}m';
+    } catch (_) {
+      timeLabel = data.timeHours;
+    }
+
+    final summary =
+        '${weightKg.toStringAsFixed(2)} kg • $timeLabel • ${data.printer} • ${data.material}';
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Text(
+              l10n.totalCostLabel,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                color: Colors.white,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            const Spacer(),
+            Text(
+              key: ValueKey<String>('$itemKeyPrefix.totalCost'),
+              data.totalCost.toStringAsFixed(2),
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                color: Colors.white,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Text(
+          key: ValueKey<String>('$itemKeyPrefix.summary'),
+          summary,
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/history/history_page.dart
+++ b/lib/history/history_page.dart
@@ -10,6 +10,7 @@ import 'package:threed_print_cost_calculator/purchases/premium_state_notifier.da
 import 'package:threed_print_cost_calculator/shared/providers/app_providers.dart';
 import 'package:threed_print_cost_calculator/shared/providers/pro_promotion_visibility.dart';
 import 'package:threed_print_cost_calculator/shared/utils/csv_utils.dart';
+import 'package:threed_print_cost_calculator/shared/utils/debounce_constants.dart';
 import 'provider/history_paged_notifier.dart';
 
 import 'components/history_empty_state.dart';
@@ -67,7 +68,7 @@ class HistoryPage extends HookConsumerWidget {
     // Debounce controller and push updates to the `historyPagedProvider` by calling setQuery.
     final debounceTimer = useRef<Timer?>(null);
     final overflowHintTimer = useRef<Timer?>(null);
-    const debounceDuration = Duration(milliseconds: 300);
+    const debounceDuration = debounce300ms;
 
     Future<void> markOverflowHintSeen() async {
       if (prefs.getBool(_overflowHintPreferenceKey) == true) return;

--- a/lib/materials/widgets/material_card.dart
+++ b/lib/materials/widgets/material_card.dart
@@ -6,6 +6,7 @@ import 'package:threed_print_cost_calculator/materials/color_utils.dart';
 import 'package:threed_print_cost_calculator/materials/model/stock_status.dart';
 import 'package:threed_print_cost_calculator/settings/model/material_model.dart';
 import 'package:threed_print_cost_calculator/shared/theme.dart';
+import 'package:threed_print_cost_calculator/shared/utils/weight_formatting.dart';
 
 class MaterialCard extends ConsumerWidget {
   final MaterialModel material;
@@ -25,12 +26,6 @@ class MaterialCard extends ConsumerWidget {
   Widget build(context, ref) {
     final l10n = AppLocalizations.of(context)!;
     final status = calculateStockStatus(material);
-
-    String formatWeight(double value) {
-      return value % 1 == 0
-          ? value.toStringAsFixed(0)
-          : value.toStringAsFixed(1);
-    }
 
     final swatchColor = colorFromMaterial(
       MaterialColorInput(

--- a/lib/settings/general_settings_form.dart
+++ b/lib/settings/general_settings_form.dart
@@ -7,6 +7,7 @@ import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
 import 'package:threed_print_cost_calculator/settings/model/general_settings_model.dart';
 import 'package:threed_print_cost_calculator/settings/services/settings_service.dart';
 import 'package:threed_print_cost_calculator/app/components/focus_safe_text_field.dart';
+import 'package:threed_print_cost_calculator/shared/utils/debounce_constants.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:threed_print_cost_calculator/shared/providers/pro_promotion_visibility.dart';
 import 'package:threed_print_cost_calculator/shared/utils/number_parsing.dart';
@@ -55,7 +56,7 @@ class GeneralSettings extends HookConsumerWidget {
       if (parsed == null) return;
 
       electricityDebounceRef.value = Timer(
-        const Duration(milliseconds: 400),
+        debounce400ms,
         () async {
           try {
             await settingsService.update(
@@ -82,7 +83,7 @@ class GeneralSettings extends HookConsumerWidget {
       if (parsed == null) return;
 
       wattDebounceRef.value = Timer(
-        const Duration(milliseconds: 400),
+        debounce400ms,
         () async {
           try {
             await settingsService.update(

--- a/lib/settings/materials/materials.dart
+++ b/lib/settings/materials/materials.dart
@@ -4,6 +4,7 @@ import 'package:threed_print_cost_calculator/database/repositories/materials_rep
 import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
 import 'package:threed_print_cost_calculator/settings/materials/material_form.dart';
 import 'package:threed_print_cost_calculator/settings/settings_slidable_item.dart';
+import 'package:threed_print_cost_calculator/shared/utils/weight_formatting.dart';
 
 class Materials extends HookConsumerWidget {
   const Materials({super.key});
@@ -12,12 +13,6 @@ class Materials extends HookConsumerWidget {
   Widget build(context, ref) {
     final materialsRepository = ref.read(materialsRepositoryProvider);
     final l10n = AppLocalizations.of(context)!;
-
-    String formatWeight(num value) {
-      return value % 1 == 0
-          ? value.toStringAsFixed(0)
-          : value.toStringAsFixed(1);
-    }
 
     return ref
         .watch(materialsStreamProvider)

--- a/lib/settings/materials/suggestion_typeahead.dart
+++ b/lib/settings/materials/suggestion_typeahead.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:threed_print_cost_calculator/app/components/focus_safe_text_field.dart';
+import 'package:threed_print_cost_calculator/shared/utils/debounce_constants.dart';
 
 class SuggestionTypeahead extends HookWidget {
   final List<String> suggestions;
@@ -33,7 +34,7 @@ class SuggestionTypeahead extends HookWidget {
       void onBlur() {
         if (focusNode.hasFocus) return;
         blurTimer?.cancel();
-        blurTimer = Timer(const Duration(milliseconds: 200), () {
+        blurTimer = Timer(debounce200ms, () {
           showSuggestions.value = false;
         });
       }

--- a/lib/settings/work_costs_form.dart
+++ b/lib/settings/work_costs_form.dart
@@ -8,6 +8,7 @@ import 'package:threed_print_cost_calculator/database/repositories/settings_repo
 import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
 import 'package:threed_print_cost_calculator/settings/model/general_settings_model.dart';
 import 'package:threed_print_cost_calculator/settings/services/settings_service.dart';
+import 'package:threed_print_cost_calculator/shared/utils/debounce_constants.dart';
 import 'package:threed_print_cost_calculator/shared/utils/numeric_input_formatters.dart';
 import 'package:threed_print_cost_calculator/shared/utils/number_parsing.dart';
 import 'package:threed_print_cost_calculator/shared/utils/text_input_normalizers.dart';
@@ -49,7 +50,7 @@ class WorkCostsSettings extends HookConsumerWidget {
     void persistFailure(String value) {
       failureDebounce.value?.cancel();
       failureDebounce.value = Timer(
-        const Duration(milliseconds: 400),
+        debounce400ms,
         () async {
           final parsed = tryParseLocalizedNum(value);
           if (parsed == null) return;
@@ -72,7 +73,7 @@ class WorkCostsSettings extends HookConsumerWidget {
 
     void persistLabour(String value) {
       labourDebounce.value?.cancel();
-      labourDebounce.value = Timer(const Duration(milliseconds: 400), () async {
+      labourDebounce.value = Timer(debounce400ms, () async {
         final parsed = tryParseLocalizedNum(value);
         if (parsed == null) return;
         try {
@@ -93,7 +94,7 @@ class WorkCostsSettings extends HookConsumerWidget {
 
     void persistWear(String value) {
       wearDebounce.value?.cancel();
-      wearDebounce.value = Timer(const Duration(milliseconds: 400), () async {
+      wearDebounce.value = Timer(debounce400ms, () async {
         final parsed = tryParseLocalizedNum(value);
         if (parsed == null) return;
         try {

--- a/lib/shared/utils/debounce_constants.dart
+++ b/lib/shared/utils/debounce_constants.dart
@@ -1,0 +1,8 @@
+/// Common debounce durations used throughout the app.
+///
+/// Use these named constants instead of inline [Duration] literals
+/// to keep debounce timing consistent across forms and pages.
+const Duration debounce200ms = Duration(milliseconds: 200);
+const Duration debounce250ms = Duration(milliseconds: 250);
+const Duration debounce300ms = Duration(milliseconds: 300);
+const Duration debounce400ms = Duration(milliseconds: 400);

--- a/lib/shared/utils/weight_formatting.dart
+++ b/lib/shared/utils/weight_formatting.dart
@@ -1,0 +1,7 @@
+/// Shared weight formatting utility.
+///
+/// Formats a numeric weight value with zero or one decimal place,
+/// suppressing the decimal point when the value is a whole number.
+String formatWeight(num value) {
+  return value % 1 == 0 ? value.toStringAsFixed(0) : value.toStringAsFixed(1);
+}


### PR DESCRIPTION
## Summary
- Deduplicate 4 identical `formatWeight` helpers into `lib/shared/utils/weight_formatting.dart`
- Replace 8 hardcoded `Duration` literals with named constants from `lib/shared/utils/debounce_constants.dart`

## Details
**formatWeight** (`num value → String`): existed identically in 4 files (materials.dart, material_row.dart, material_select.dart, material_card.dart). Now a single shared utility.

**Debounce constants**: 200ms (suggestion_typeahead), 250ms (calculator_notifier), 300ms (history_page), 400ms (general_settings x2, work_costs x3).

No behavior changes. Analyzer clean. 365 tests pass.

ClickUp: 86c9qf1ga