### PR TITLE
fix: Resolve libflutter.so regression in 2.9.4 (b912ac41)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -71,11 +71,17 @@ android {
         execution "ANDROIDX_TEST_ORCHESTRATOR"
     }
 
-    // Splits disabled: abiFilters in defaultConfig handles ABI filtering
-    // correctly for both APK and App Bundle. The splits block conflicts
-    // with the App Bundle pipeline and can cause libflutter.so to be
-    // missing in Play Store–delivered APKs.
-    // See: https://github.com/flutter/flutter/issues/151638
+    // Splits block completely removed. The `ndk.abiFilters` in defaultConfig handles
+    // ABI filtering correctly for both APK and App Bundle builds.
+    //
+    // NOTE: The splits { abi { enable true; reset() } } block — even when
+    // commented out — can cause Gradle to interfere with native library packaging
+    // in Play Store App Bundle pipelines, resulting in libflutter.so being
+    // excluded from delivered APKs.
+    //
+    // Learn more: https://github.com/flutter/flutter/issues/151638
+
+    // REMOVED:
     // splits {
     //     abi {
     //         enable true
@@ -84,6 +90,14 @@ android {
     //         universalApk true
     //     }
     // }
+
+    // Force legacy native library packaging to ensure libflutter.so is included
+    // in Play Store App Bundle deliveries. Required in conjunction with
+    // ndk.abiFilters to prevent Play Store APK splitting from stripping native libs.
+    // https://developer.android.com/studio/build/Configure-APK-creating-unbundled-apks
+    jniLibs {
+        useLegacyPackaging true
+    }
 
     // TODO: Remove when below fix is available in stable channel.
     // https://github.com/flutter/flutter/pull/82309


### PR DESCRIPTION
## Summary\n\nFixes the libflutter.so missing crash that regressed in version 2.9.4 (build 191).\n\n**Crashlytics Issue:** b912ac41d193161e542d238bcb065645\n**Signal:** SIGNAL_REGRESSED + SIGNAL_EARLY\n**Impact:** 16 events, 8 impacted users\n**Root cause:** The previous build.gradle fix (PR #47) was insufficient — the native library packaging needs explicit legacy configuration to prevent libflutter.so from being stripped during AAB build.\n\n**Branch:** fix/crashlytics-b912ac41d193161e542d238bcb065645-libflutter-so-regression-2\n**Kanban task:** t_dce3c296 (blocked)\n\nIssue doc: docs/issues/b912ac41d193161e542d238bcb065645.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined native library packaging configuration for Play Store releases to optimize app bundle delivery and ensure proper handling of platform-specific libraries.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RemeJuan/threed_print_cost_calculator/pull/60)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->