### PR TITLE
fix: Wrap cancel feedback sheet in addPostFrameCallback to prevent ANR regression (8aeb52bf)

### DIFF
--- a/lib/app/app_page.dart
+++ b/lib/app/app_page.dart
@@ -116,14 +116,17 @@ class AppPage extends HookConsumerWidget {
       await cancelFeedbackService.markPromptShown(next);
       if (!context.mounted) return;
 
-      await showCancelFeedbackSheet(
-        context,
-        onDismiss: () => cancelFeedbackService.dismissFeedback(next),
-        onSubmitted: (reason) => cancelFeedbackService.submitFeedback(
-          state: next,
-          reason: reason.analyticsValue,
-        ),
-      );
+      WidgetsBinding.instance.addPostFrameCallback((_) async {
+        if (!context.mounted) return;
+        await showCancelFeedbackSheet(
+          context,
+          onDismiss: () => cancelFeedbackService.dismissFeedback(next),
+          onSubmitted: (reason) => cancelFeedbackService.submitFeedback(
+            state: next,
+            reason: reason.analyticsValue,
+          ),
+        );
+      });
     });
 
     final pageController = usePageController(initialPage: 0);


### PR DESCRIPTION
## Summary\n\nResolves FlutterJNI  ANR regression (issue 8aeb52bf) that recurred in version 2.9.4.\n\n**Root cause:** The  call was made synchronously inside a lifecycle state change handler. On certain devices, this synchronous sheet presentation during a lifecycle transition triggers a main-thread layout pass that calls into native code, causing the ANR.\n\n**Fix:** Wrap  in  to defer the sheet presentation to the next frame, ensuring the app lifecycle state is fully settled before any UI operations.\n\n**Changed file:**  (+11, -8 lines)\n\n**Verification:**\n- Analyzing app_page.dart...                                      
No issues found! (ran in 1.9s) — 0 issues\n- 00:00 +0: loading /Users/remelehane/Projects/threed_print_cost_calculator/test/app/view/app_page_test.dart
00:00 +0: (setUpAll)
00:00 +0: shows free nav without history
00:00 +1: does not show whats new when app page route is not current
00:00 +2: shows teaser history tab for free users when promos enabled
00:00 +3: free users can hide history promo and premium users always see history
00:00 +4: premium changes update nav items from gateway updates
00:00 +5: opening materials tab logs analytics once per open
00:00 +6: premium app bar icons match the source of truth
DEBUG [provider] History page load started | hasQuery=false, page=0, reset=true
DEBUG [provider] History page load completed | hasMore=false, hasQuery=false, itemCount=0, page=0, reset=true, totalLoaded=0
00:01 +7: free app bar icons match the source of truth
00:01 +8: selected index clamps when history tab disappears
00:01 +9: swiping between pages updates bottom navigation selection
DEBUG [provider] History page load started | hasQuery=false, page=0, reset=true
DEBUG [provider] History page load completed | hasMore=false, hasQuery=false, itemCount=0, page=0, reset=true, totalLoaded=0
00:01 +10: history selection falls back to calculator when tab disappears
00:01 +11: upgrading from teaser history unlocks full history immediately
DEBUG [provider] History page load started | hasQuery=false, page=0, reset=true
DEBUG [provider] History page load completed | hasMore=false, hasQuery=false, itemCount=0, page=0, reset=true, totalLoaded=0
00:01 +12: re-enabling history promo keeps settings selected
00:01 +13: run count increments on resolved non-empty user ids only
00:01 +14: startup calculator init and submit are wired
00:01 +15: help support page still exposes hidden tools tap target
00:01 +16: (tearDownAll)
00:01 +16: All tests passed! — 16/16 passed\n\n**Note:** The original regression fix branch () had 57 files changed with unrelated work. This is a clean branch containing only the targeted fix.\n\n**Crashlytics Issue:** 8aeb52bf4fad6628513cae2330651dd6\n**Signal:** SIGNAL_REGRESSED + SIGNAL_EARLY\n**Impact:** Regression in v2.9.4\n\nIssue doc: docs/issues/8aeb52bf4fad6628513cae2330651dd6.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved cancel feedback sheet display performance for smoother user experience.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RemeJuan/threed_print_cost_calculator/pull/62)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->