### PR TITLE
[86c9u8c6z]: gate hidden batch costing flow

### DIFF
--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -978,6 +978,18 @@ abstract class AppLocalizations {
   /// **'Preview renewal feedback'**
   String get previewCancelFeedbackButton;
 
+  /// No description provided for @enableBatchCostingButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Enable batch costing'**
+  String get enableBatchCostingButton;
+
+  /// No description provided for @showWhatsNewButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Show What\'s New'**
+  String get showWhatsNewButton;
+
   /// No description provided for @enablePremiumTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -472,6 +472,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get previewCancelFeedbackButton => 'Rückmeldeansicht zur Verlängerung';
 
   @override
+  String get enableBatchCostingButton => 'Enable batch costing';
+
+  @override
+  String get showWhatsNewButton => 'Show What\'s New';
+
+  @override
   String get enablePremiumTitle => 'Premium aktivieren';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -470,6 +470,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get previewCancelFeedbackButton => 'Preview renewal feedback';
 
   @override
+  String get enableBatchCostingButton => 'Enable batch costing';
+
+  @override
+  String get showWhatsNewButton => 'Show What\'s New';
+
+  @override
   String get enablePremiumTitle => 'Enable premium';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -474,6 +474,12 @@ class AppLocalizationsEs extends AppLocalizations {
       'Vista previa de comentarios de cancelación';
 
   @override
+  String get enableBatchCostingButton => 'Enable batch costing';
+
+  @override
+  String get showWhatsNewButton => 'Show What\'s New';
+
+  @override
   String get enablePremiumTitle => 'Activar premium';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -477,6 +477,12 @@ class AppLocalizationsFr extends AppLocalizations {
       'Aperçu des commentaires d\'annulation';
 
   @override
+  String get enableBatchCostingButton => 'Enable batch costing';
+
+  @override
+  String get showWhatsNewButton => 'Show What\'s New';
+
+  @override
   String get enablePremiumTitle => 'Activer le premium';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -472,6 +472,12 @@ class AppLocalizationsId extends AppLocalizations {
   String get previewCancelFeedbackButton => 'Pratinjau umpan balik pembatalan';
 
   @override
+  String get enableBatchCostingButton => 'Enable batch costing';
+
+  @override
+  String get showWhatsNewButton => 'Show What\'s New';
+
+  @override
   String get enablePremiumTitle => 'Aktifkan premium';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -475,6 +475,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get previewCancelFeedbackButton => 'Anteprima feedback annullamento';
 
   @override
+  String get enableBatchCostingButton => 'Enable batch costing';
+
+  @override
+  String get showWhatsNewButton => 'Show What\'s New';
+
+  @override
   String get enablePremiumTitle => 'Attiva premium';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -461,6 +461,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get previewCancelFeedbackButton => '取消フィードバックをプレビュー';
 
   @override
+  String get enableBatchCostingButton => 'Enable batch costing';
+
+  @override
+  String get showWhatsNewButton => 'Show What\'s New';
+
+  @override
   String get enablePremiumTitle => 'プレミアムを有効化';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -472,6 +472,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get previewCancelFeedbackButton => 'Voorvertoning annuleringsfeedback';
 
   @override
+  String get enableBatchCostingButton => 'Enable batch costing';
+
+  @override
+  String get showWhatsNewButton => 'Show What\'s New';
+
+  @override
   String get enablePremiumTitle => 'Premium inschakelen';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -473,6 +473,12 @@ class AppLocalizationsPt extends AppLocalizations {
       'Prévia do feedback de cancelamento';
 
   @override
+  String get enableBatchCostingButton => 'Enable batch costing';
+
+  @override
+  String get showWhatsNewButton => 'Show What\'s New';
+
+  @override
   String get enablePremiumTitle => 'Ativar premium';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -468,6 +468,12 @@ class AppLocalizationsTh extends AppLocalizations {
   String get previewCancelFeedbackButton => 'ดูตัวอย่างความคิดเห็นการยกเลิก';
 
   @override
+  String get enableBatchCostingButton => 'Enable batch costing';
+
+  @override
+  String get showWhatsNewButton => 'Show What\'s New';
+
+  @override
   String get enablePremiumTitle => 'เปิดใช้งานพรีเมียม';
 
   @override

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -334,6 +334,8 @@
   "forceNoUpdateButton": "Kein Update erzwingen",
   "clearUpdateCooldownButton": "Update-Wartezeit löschen",
   "previewCancelFeedbackButton": "Rückmeldeansicht zur Verlängerung",
+  "enableBatchCostingButton": "Enable batch costing",
+  "showWhatsNewButton": "Show What's New",
   "enablePremiumTitle": "Premium aktivieren",
   "enablePremiumBody": "Bestätigungscode eingeben, um lokale Premium-Tests zu aktivieren",
   "invalidConfirmationCodeMessage": "Ungültiger Bestätigungscode",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -189,6 +189,8 @@
   "forceNoUpdateButton": "Force no update",
   "clearUpdateCooldownButton": "Clear update cooldown",
   "previewCancelFeedbackButton": "Preview renewal feedback",
+  "enableBatchCostingButton": "Enable batch costing",
+  "showWhatsNewButton": "Show What's New",
   "enablePremiumTitle": "Enable premium",
   "enablePremiumBody": "Enter confirmation code to enable local premium testing",
   "invalidConfirmationCodeMessage": "Invalid confirmation code",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -327,6 +327,8 @@
   "forceNoUpdateButton": "Forzar sin actualización",
   "clearUpdateCooldownButton": "Borrar pausa de actualización",
   "previewCancelFeedbackButton": "Vista previa de comentarios de cancelación",
+  "enableBatchCostingButton": "Enable batch costing",
+  "showWhatsNewButton": "Show What's New",
   "enablePremiumTitle": "Activar premium",
   "enablePremiumBody": "Introduce el código de confirmación para activar las pruebas locales de premium",
   "invalidConfirmationCodeMessage": "Código de confirmación inválido",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -336,6 +336,8 @@
   "forceNoUpdateButton": "Forcer aucune mise à jour",
   "clearUpdateCooldownButton": "Effacer le délai de mise à jour",
   "previewCancelFeedbackButton": "Aperçu des commentaires d'annulation",
+  "enableBatchCostingButton": "Enable batch costing",
+  "showWhatsNewButton": "Show What's New",
   "enablePremiumTitle": "Activer le premium",
   "enablePremiumBody": "Saisissez le code de confirmation pour activer les tests premium locaux",
   "invalidConfirmationCodeMessage": "Code de confirmation invalide",

--- a/lib/l10n/intl_id.arb
+++ b/lib/l10n/intl_id.arb
@@ -328,6 +328,8 @@
   "forceNoUpdateButton": "Paksa tidak ada pembaruan",
   "clearUpdateCooldownButton": "Hapus jeda pembaruan",
   "previewCancelFeedbackButton": "Pratinjau umpan balik pembatalan",
+  "enableBatchCostingButton": "Enable batch costing",
+  "showWhatsNewButton": "Show What's New",
   "enablePremiumTitle": "Aktifkan premium",
   "enablePremiumBody": "Masukkan kode konfirmasi untuk mengaktifkan pengujian premium lokal",
   "invalidConfirmationCodeMessage": "Kode konfirmasi tidak valid",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -328,6 +328,8 @@
   "forceNoUpdateButton": "Forza nessun aggiornamento",
   "clearUpdateCooldownButton": "Cancella attesa aggiornamento",
   "previewCancelFeedbackButton": "Anteprima feedback annullamento",
+  "enableBatchCostingButton": "Enable batch costing",
+  "showWhatsNewButton": "Show What's New",
   "enablePremiumTitle": "Attiva premium",
   "enablePremiumBody": "Inserisci il codice di conferma per attivare i test premium locali",
   "invalidConfirmationCodeMessage": "Codice di conferma non valido",

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -336,6 +336,8 @@
   "forceNoUpdateButton": "更新なしを強制",
   "clearUpdateCooldownButton": "更新クールダウンを消去",
   "previewCancelFeedbackButton": "取消フィードバックをプレビュー",
+  "enableBatchCostingButton": "Enable batch costing",
+  "showWhatsNewButton": "Show What's New",
   "enablePremiumTitle": "プレミアムを有効化",
   "enablePremiumBody": "ローカルのプレミアムテストを有効にする確認コードを入力してください",
   "invalidConfirmationCodeMessage": "確認コードが無効です",

--- a/lib/l10n/intl_nl.arb
+++ b/lib/l10n/intl_nl.arb
@@ -336,6 +336,8 @@
   "forceNoUpdateButton": "Geen update forceren",
   "clearUpdateCooldownButton": "Update-afkoeling wissen",
   "previewCancelFeedbackButton": "Voorvertoning annuleringsfeedback",
+  "enableBatchCostingButton": "Enable batch costing",
+  "showWhatsNewButton": "Show What's New",
   "enablePremiumTitle": "Premium inschakelen",
   "enablePremiumBody": "Voer de bevestigingscode in om lokale premiumtests in te schakelen",
   "invalidConfirmationCodeMessage": "Ongeldige bevestigingscode",

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -335,6 +335,8 @@
   "forceNoUpdateButton": "Forçar sem atualização",
   "clearUpdateCooldownButton": "Limpar espera de atualização",
   "previewCancelFeedbackButton": "Prévia do feedback de cancelamento",
+  "enableBatchCostingButton": "Enable batch costing",
+  "showWhatsNewButton": "Show What's New",
   "enablePremiumTitle": "Ativar premium",
   "enablePremiumBody": "Insira o código de confirmação para ativar os testes locais de premium",
   "invalidConfirmationCodeMessage": "Código de confirmação inválido",

--- a/lib/l10n/intl_th.arb
+++ b/lib/l10n/intl_th.arb
@@ -329,6 +329,8 @@
   "forceNoUpdateButton": "บังคับว่าไม่มีอัปเดต",
   "clearUpdateCooldownButton": "ล้างช่วงพักอัปเดต",
   "previewCancelFeedbackButton": "ดูตัวอย่างความคิดเห็นการยกเลิก",
+  "enableBatchCostingButton": "Enable batch costing",
+  "showWhatsNewButton": "Show What's New",
   "enablePremiumTitle": "เปิดใช้งานพรีเมียม",
   "enablePremiumBody": "ป้อนรหัสยืนยันเพื่อเปิดการทดสอบพรีเมียมภายในเครื่อง",
   "invalidConfirmationCodeMessage": "รหัสยืนยันไม่ถูกต้อง",

--- a/lib/shared/components/settings_version_tap_target.dart
+++ b/lib/shared/components/settings_version_tap_target.dart
@@ -13,6 +13,7 @@ import 'package:threed_print_cost_calculator/history/provider/history_providers.
 import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
 import 'package:threed_print_cost_calculator/purchases/premium_state_notifier.dart';
 import 'package:threed_print_cost_calculator/shared/components/whats_new_sheet.dart';
+import 'package:threed_print_cost_calculator/shared/providers/batch_costing_visibility.dart';
 import 'package:threed_print_cost_calculator/shared/providers/app_providers.dart';
 import 'package:threed_print_cost_calculator/shared/providers/update_checker_provider.dart';
 import 'package:threed_print_cost_calculator/shared/providers/whats_new_provider.dart';
@@ -113,6 +114,11 @@ class _SettingsVersionTapTargetState
           messenger: messenger,
           l10n: l10n,
         );
+        break;
+      case TestDataAction.enableBatchCosting:
+        await container
+            .read(batchCostingEnabledProvider.notifier)
+            .setBatchCostingEnabled(true);
         break;
       case TestDataAction.forceUpdateAvailable:
         container.read(updateCheckerProvider.notifier).forceAvailable();

--- a/lib/shared/providers/batch_costing_visibility.dart
+++ b/lib/shared/providers/batch_costing_visibility.dart
@@ -1,0 +1,25 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:threed_print_cost_calculator/shared/providers/app_providers.dart';
+
+const batchCostingEnabledPreferenceKey = 'batchCostingEnabled';
+
+final batchCostingEnabledProvider =
+    NotifierProvider<BatchCostingEnabledNotifier, bool>(
+      BatchCostingEnabledNotifier.new,
+    );
+
+class BatchCostingEnabledNotifier extends Notifier<bool> {
+  SharedPreferences get _prefs => ref.read(sharedPreferencesProvider);
+
+  @override
+  bool build() {
+    return _prefs.getBool(batchCostingEnabledPreferenceKey) ?? false;
+  }
+
+  Future<void> setBatchCostingEnabled(bool value) async {
+    state = value;
+    await _prefs.setBool(batchCostingEnabledPreferenceKey, value);
+  }
+}

--- a/lib/shared/test_tools/test_data_tools_dialog.dart
+++ b/lib/shared/test_tools/test_data_tools_dialog.dart
@@ -55,7 +55,7 @@ class TestDataToolsDialog extends StatelessWidget {
                   'settings.testData.enableBatchCosting.button',
                 ),
                 onPressed: () => onAction(TestDataAction.enableBatchCosting),
-                child: const Text('Enable batch costing'),
+                child: Text(l10n.enableBatchCostingButton),
               ),
               TextButton(
                 key: const ValueKey<String>(
@@ -90,7 +90,7 @@ class TestDataToolsDialog extends StatelessWidget {
                   'settings.testData.showWhatsNew.button',
                 ),
                 onPressed: () => onAction(TestDataAction.showWhatsNew),
-                child: const Text('Show What\'s New'),
+                child: Text(l10n.showWhatsNewButton),
               ),
             ],
           ),

--- a/lib/shared/test_tools/test_data_tools_dialog.dart
+++ b/lib/shared/test_tools/test_data_tools_dialog.dart
@@ -5,6 +5,7 @@ enum TestDataAction {
   seed,
   purge,
   enablePremium,
+  enableBatchCosting,
   forceUpdateAvailable,
   forceNoUpdate,
   clearUpdateCooldown,
@@ -23,52 +24,79 @@ class TestDataToolsDialog extends StatelessWidget {
     return AlertDialog(
       key: const ValueKey<String>('settings.testData.tools.dialog'),
       title: Text(l10n.testDataToolsTitle),
-      content: Text(l10n.testDataToolsBody),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(l10n.testDataToolsBody),
+              const SizedBox(height: 12),
+              TextButton(
+                key: const ValueKey<String>('settings.testData.seed.button'),
+                onPressed: () => onAction(TestDataAction.seed),
+                child: Text(l10n.seedTestDataButton),
+              ),
+              TextButton(
+                key: const ValueKey<String>('settings.testData.purge.button'),
+                onPressed: () => onAction(TestDataAction.purge),
+                child: Text(l10n.purgeLocalDataButton),
+              ),
+              TextButton(
+                key: const ValueKey<String>(
+                  'settings.testData.enablePremium.button',
+                ),
+                onPressed: () => onAction(TestDataAction.enablePremium),
+                child: Text(l10n.enablePremiumButton),
+              ),
+              TextButton(
+                key: const ValueKey<String>(
+                  'settings.testData.enableBatchCosting.button',
+                ),
+                onPressed: () => onAction(TestDataAction.enableBatchCosting),
+                child: const Text('Enable batch costing'),
+              ),
+              TextButton(
+                key: const ValueKey<String>(
+                  'settings.testData.forceUpdate.button',
+                ),
+                onPressed: () => onAction(TestDataAction.forceUpdateAvailable),
+                child: Text(l10n.forceUpdateAvailableButton),
+              ),
+              TextButton(
+                key: const ValueKey<String>(
+                  'settings.testData.forceNoUpdate.button',
+                ),
+                onPressed: () => onAction(TestDataAction.forceNoUpdate),
+                child: Text(l10n.forceNoUpdateButton),
+              ),
+              TextButton(
+                key: const ValueKey<String>(
+                  'settings.testData.clearUpdateCooldown.button',
+                ),
+                onPressed: () => onAction(TestDataAction.clearUpdateCooldown),
+                child: Text(l10n.clearUpdateCooldownButton),
+              ),
+              TextButton(
+                key: const ValueKey<String>(
+                  'settings.testData.previewCancelFeedback.button',
+                ),
+                onPressed: () => onAction(TestDataAction.previewCancelFeedback),
+                child: Text(l10n.previewCancelFeedbackButton),
+              ),
+              TextButton(
+                key: const ValueKey<String>(
+                  'settings.testData.showWhatsNew.button',
+                ),
+                onPressed: () => onAction(TestDataAction.showWhatsNew),
+                child: const Text('Show What\'s New'),
+              ),
+            ],
+          ),
+        ),
+      ),
       actions: [
-        TextButton(
-          key: const ValueKey<String>('settings.testData.seed.button'),
-          onPressed: () => onAction(TestDataAction.seed),
-          child: Text(l10n.seedTestDataButton),
-        ),
-        TextButton(
-          key: const ValueKey<String>('settings.testData.purge.button'),
-          onPressed: () => onAction(TestDataAction.purge),
-          child: Text(l10n.purgeLocalDataButton),
-        ),
-        TextButton(
-          key: const ValueKey<String>('settings.testData.enablePremium.button'),
-          onPressed: () => onAction(TestDataAction.enablePremium),
-          child: Text(l10n.enablePremiumButton),
-        ),
-        TextButton(
-          key: const ValueKey<String>('settings.testData.forceUpdate.button'),
-          onPressed: () => onAction(TestDataAction.forceUpdateAvailable),
-          child: Text(l10n.forceUpdateAvailableButton),
-        ),
-        TextButton(
-          key: const ValueKey<String>('settings.testData.forceNoUpdate.button'),
-          onPressed: () => onAction(TestDataAction.forceNoUpdate),
-          child: Text(l10n.forceNoUpdateButton),
-        ),
-        TextButton(
-          key: const ValueKey<String>(
-            'settings.testData.clearUpdateCooldown.button',
-          ),
-          onPressed: () => onAction(TestDataAction.clearUpdateCooldown),
-          child: Text(l10n.clearUpdateCooldownButton),
-        ),
-        TextButton(
-          key: const ValueKey<String>(
-            'settings.testData.previewCancelFeedback.button',
-          ),
-          onPressed: () => onAction(TestDataAction.previewCancelFeedback),
-          child: Text(l10n.previewCancelFeedbackButton),
-        ),
-        TextButton(
-          key: const ValueKey<String>('settings.testData.showWhatsNew.button'),
-          onPressed: () => onAction(TestDataAction.showWhatsNew),
-          child: const Text('Show What\'s New'),
-        ),
         TextButton(
           key: const ValueKey<String>('settings.testData.cancel.button'),
           onPressed: () => onAction(null),

--- a/test/shared/components/settings_version_tap_target_test.dart
+++ b/test/shared/components/settings_version_tap_target_test.dart
@@ -9,6 +9,7 @@ import 'package:threed_print_cost_calculator/calculator/provider/calculator_noti
 import 'package:threed_print_cost_calculator/history/provider/history_paged_notifier.dart';
 import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
 import 'package:threed_print_cost_calculator/shared/components/settings_version_tap_target.dart';
+import 'package:threed_print_cost_calculator/shared/providers/batch_costing_visibility.dart';
 import 'package:threed_print_cost_calculator/shared/providers/app_providers.dart';
 import 'package:threed_print_cost_calculator/shared/test_tools/seed_loader.dart';
 import 'package:threed_print_cost_calculator/shared/test_tools/test_data_service.dart';
@@ -81,6 +82,15 @@ Future<void> _openHiddenTools(WidgetTester tester) async {
     await tester.tap(target);
     await tester.pump(const Duration(milliseconds: 200));
   }
+  await tester.pumpAndSettle();
+}
+
+Future<void> _revealHiddenToolButton(WidgetTester tester, String key) async {
+  await tester.dragUntilVisible(
+    find.byKey(ValueKey<String>(key)),
+    find.byType(SingleChildScrollView),
+    const Offset(0, -200),
+  );
   await tester.pumpAndSettle();
 }
 
@@ -217,6 +227,10 @@ void main() {
     await tester.pumpAndSettle();
     await _openHiddenTools(tester);
 
+    await _revealHiddenToolButton(
+      tester,
+      'settings.testData.previewCancelFeedback.button',
+    );
     await tester.tap(
       find.byKey(
         const ValueKey<String>(
@@ -248,6 +262,10 @@ void main() {
     await tester.pumpAndSettle();
     await _openHiddenTools(tester);
 
+    await _revealHiddenToolButton(
+      tester,
+      'settings.testData.showWhatsNew.button',
+    );
     await tester.tap(
       find.byKey(
         const ValueKey<String>('settings.testData.showWhatsNew.button'),
@@ -266,5 +284,40 @@ void main() {
 
     expect(fakeAnalytics.lastName, 'whats_new_dismissed');
     expect(fakeAnalytics.lastParams?['wn_id'], 'pricing_model_2026_05');
+  });
+
+  testWidgets('can enable batch costing from hidden tools', (tester) async {
+    final fakeCalculator = FakeCalculatorNotifier();
+    final fakeHistory = _FakeHistoryPagedNotifier();
+
+    final db = await tester.pumpApp(const SettingsVersionTapTarget(), [
+      calculatorProvider.overrideWith(() => fakeCalculator),
+      historyPagedProvider.overrideWith(() => fakeHistory),
+      testDataServiceProvider.overrideWith((ref) => _FakeTestDataService(ref)),
+    ]);
+    addTearDown(() => db.close());
+
+    await tester.pumpAndSettle();
+    await _openHiddenTools(tester);
+
+    await _revealHiddenToolButton(
+      tester,
+      'settings.testData.enableBatchCosting.button',
+    );
+    await tester.tap(
+      find.byKey(
+        const ValueKey<String>('settings.testData.enableBatchCosting.button'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final container = ProviderScope.containerOf(
+      tester.element(
+        find.byKey(const ValueKey<String>('settings.version.tapTarget')),
+      ),
+      listen: false,
+    );
+
+    expect(container.read(batchCostingEnabledProvider), isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- Add a shared batch-costing visibility flag backed by SharedPreferences.
- Expose a hidden developer-only test tool to enable batch costing.
- Cover the hidden-tools flow in widget tests and make the dialog scrollable on small surfaces.

## Verification
- `fvm dart format test/shared/components/settings_version_tap_target_test.dart`
- `fvm flutter test test/shared/components/settings_version_tap_target_test.dart`
- `fvm flutter analyze` (one pre-existing info in `lib/gcode_import/model/gcode_import_result_models.dart:78`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toggle to enable batch costing from the test-data tools
  * Batch costing preference now persists across sessions

* **UI Improvements**
  * Reorganized test-data tools dialog into a scrollable, full-width content area

* **Localization**
  * Added "Enable batch costing" and "Show What's New" labels for multiple locales

* **Tests**
  * Added/updated UI tests to cover enabling batch costing and hidden-tool reveal behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RemeJuan/threed_print_cost_calculator/pull/71)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->