### PR TITLE
feat(batch-costing): add hidden entry shell

### DIFF
--- a/lib/batch_costing/batch_costing_page.dart
+++ b/lib/batch_costing/batch_costing_page.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:threed_print_cost_calculator/shared/providers/batch_costing_visibility.dart';
+
+class BatchCostingPage extends ConsumerWidget {
+  const BatchCostingPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!ref.watch(batchCostingEnabledProvider)) {
+      return const SizedBox.shrink();
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Batch costing')),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text('Choose how to start batch costing.'),
+            const SizedBox(height: 16),
+            OutlinedButton.icon(
+              onPressed: null,
+              icon: const Icon(Icons.upload_file_outlined),
+              label: const Text('Import G-code batch'),
+            ),
+            const SizedBox(height: 12),
+            OutlinedButton.icon(
+              onPressed: null,
+              icon: const Icon(Icons.edit_outlined),
+              label: const Text('Manual batch'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/calculator/view/calculator_page.dart
+++ b/lib/calculator/view/calculator_page.dart
@@ -8,6 +8,7 @@ import 'package:threed_print_cost_calculator/calculator/view/printer_select.dart
 import 'package:threed_print_cost_calculator/calculator/view/save_form.dart';
 import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
 import 'package:threed_print_cost_calculator/purchases/premium_state_notifier.dart';
+import 'package:threed_print_cost_calculator/shared/providers/batch_costing_visibility.dart';
 import 'package:threed_print_cost_calculator/shared/theme.dart';
 import 'package:threed_print_cost_calculator/shared/providers/app_providers.dart';
 
@@ -17,6 +18,7 @@ import 'components/job_pricing_overrides_section.dart';
 import 'components/materials_selection/materials_section.dart';
 import 'components/time_section.dart';
 import 'package:threed_print_cost_calculator/purchases/paywall_presenter.dart';
+import 'package:threed_print_cost_calculator/batch_costing/batch_costing_page.dart';
 
 class CalculatorPage extends HookConsumerWidget {
   const CalculatorPage({super.key});
@@ -167,6 +169,23 @@ class CalculatorPage extends HookConsumerWidget {
                 ],
               ],
             ),
+            if (ref.watch(batchCostingEnabledProvider)) ...[
+              const SizedBox(height: 12),
+              OutlinedButton.icon(
+                key: const ValueKey<String>(
+                  'calculator.batch_costing.open.button',
+                ),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => const BatchCostingPage(),
+                    ),
+                  );
+                },
+                icon: const Icon(Icons.view_list_outlined),
+                label: const Text('Batch costing'),
+              ),
+            ],
             if (showSave.value)
               SaveForm(
                 data: state.results,

--- a/test/calculator/view/calculator_page_test.dart
+++ b/test/calculator/view/calculator_page_test.dart
@@ -6,6 +6,7 @@ import 'package:threed_print_cost_calculator/calculator/provider/calculator_noti
 import 'package:threed_print_cost_calculator/calculator/view/calculator_page.dart';
 import 'package:threed_print_cost_calculator/calculator/view/components/materials_selection/materials_section.dart';
 import 'package:threed_print_cost_calculator/database/database_helpers.dart';
+import 'package:threed_print_cost_calculator/shared/providers/batch_costing_visibility.dart';
 
 import '../../helpers/helpers.dart';
 import '../../helpers/mocks.dart';
@@ -32,6 +33,44 @@ void main() {
       addTearDown(() => db.close());
       await tester.pumpAndSettle();
       expect(find.byType(CalculatorPage), findsOneWidget);
+    });
+
+    testWidgets('hides batch costing entry when disabled', (tester) async {
+      final db = await tester.pumpApp(const CalculatorPage(), [
+        calculatorProvider.overrideWith(() => mockCalculatorProvider),
+      ]);
+      addTearDown(() => db.close());
+
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(
+          const ValueKey<String>('calculator.batch_costing.open.button'),
+        ),
+        findsNothing,
+      );
+    });
+
+    testWidgets('opens batch costing shell when enabled', (tester) async {
+      SharedPreferences.setMockInitialValues({
+        batchCostingEnabledPreferenceKey: true,
+      });
+      final db = await tester.pumpApp(const CalculatorPage(), [
+        calculatorProvider.overrideWith(() => mockCalculatorProvider),
+      ]);
+      addTearDown(() => db.close());
+
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.byKey(
+          const ValueKey<String>('calculator.batch_costing.open.button'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Batch costing'), findsOneWidget);
+      expect(find.text('Choose how to start batch costing.'), findsOneWidget);
     });
 
     testWidgets(


### PR DESCRIPTION
## Summary
- Add a hidden batch costing entry button on the calculator screen, gated by `batchCostingEnabled`.
- Add a gated batch costing shell screen with disabled starter actions for the two planned entry paths.
- Cover the hidden/visible states with widget tests.

## Validation
- `fvm flutter analyze`
- `fvm flutter test test/calculator/view/calculator_page_test.dart test/shared/components/settings_version_tap_target_test.dart`

## Intentionally left out
- Actual batch costing calculations and item flow
- Persistence/history/export work
- Localization for the dev-only shell copy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch costing page with "Import G-code batch" and "Manual batch" options.
  * Added batch costing navigation button to calculator view.

* **Tests**
  * Added test cases verifying batch costing button visibility toggle and UI rendering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RemeJuan/threed_print_cost_calculator/pull/72)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->