### PR TITLE
[86c9u8da6]: add batch costing item model

### DIFF
--- a/lib/batch_costing/model/batch_costing_item.dart
+++ b/lib/batch_costing/model/batch_costing_item.dart
@@ -35,7 +35,7 @@ class BatchCostingImportMetadata {
 }
 
 class BatchCostingItem {
-  BatchCostingItem({
+  BatchCostingItem._({
     required this.id,
     required this.displayName,
     required int quantity,
@@ -72,7 +72,7 @@ class BatchCostingItem {
     String? materialId,
     String? pricingProfileId,
   }) {
-    return BatchCostingItem(
+    return BatchCostingItem._(
       id: id,
       displayName: displayName,
       sourceFileName: sourceFileName,
@@ -114,7 +114,7 @@ class BatchCostingItem {
       );
     }
 
-    return BatchCostingItem(
+    return BatchCostingItem._(
       id: id,
       displayName: displayName,
       sourceFileName: sourceFileName,
@@ -148,7 +148,7 @@ class BatchCostingItem {
     String? materialId,
     String? pricingProfileId,
   }) {
-    return BatchCostingItem(
+    return BatchCostingItem._(
       id: id ?? this.id,
       displayName: displayName ?? this.displayName,
       sourceFileName: sourceFileName ?? this.sourceFileName,

--- a/lib/batch_costing/model/batch_costing_item.dart
+++ b/lib/batch_costing/model/batch_costing_item.dart
@@ -1,0 +1,172 @@
+import 'package:threed_print_cost_calculator/gcode_import/gcode_import_result.dart';
+
+enum BatchCostingItemSourceType { manual, gcode }
+
+class BatchCostingImportMetadata {
+  const BatchCostingImportMetadata({
+    this.sourceFileName,
+    this.sourcePath,
+    this.slicer,
+    this.hasSafePreview = false,
+    this.rawExtractedValues = const <String, String>{},
+  });
+
+  final String? sourceFileName;
+  final String? sourcePath;
+  final GCodeSlicer? slicer;
+  final bool hasSafePreview;
+  final Map<String, String> rawExtractedValues;
+
+  BatchCostingImportMetadata copyWith({
+    String? sourceFileName,
+    String? sourcePath,
+    GCodeSlicer? slicer,
+    bool? hasSafePreview,
+    Map<String, String>? rawExtractedValues,
+  }) {
+    return BatchCostingImportMetadata(
+      sourceFileName: sourceFileName ?? this.sourceFileName,
+      sourcePath: sourcePath ?? this.sourcePath,
+      slicer: slicer ?? this.slicer,
+      hasSafePreview: hasSafePreview ?? this.hasSafePreview,
+      rawExtractedValues: rawExtractedValues ?? this.rawExtractedValues,
+    );
+  }
+}
+
+class BatchCostingItem {
+  BatchCostingItem({
+    required this.id,
+    required this.displayName,
+    required int quantity,
+    required this.printWeightG,
+    required this.printDuration,
+    this.sourceFileName,
+    this.sourceType,
+    this.importMetadata,
+    this.printerId,
+    this.materialId,
+    this.pricingProfileId,
+  }) : quantity = _validateQuantity(quantity);
+
+  final String id;
+  final String displayName;
+  final String? sourceFileName;
+  final int quantity;
+  final double printWeightG;
+  final Duration printDuration;
+  final BatchCostingItemSourceType? sourceType;
+  final BatchCostingImportMetadata? importMetadata;
+  final String? printerId;
+  final String? materialId;
+  final String? pricingProfileId;
+
+  factory BatchCostingItem.manual({
+    required String id,
+    required String displayName,
+    required int quantity,
+    required double printWeightG,
+    required Duration printDuration,
+    String? sourceFileName,
+    String? printerId,
+    String? materialId,
+    String? pricingProfileId,
+  }) {
+    return BatchCostingItem(
+      id: id,
+      displayName: displayName,
+      sourceFileName: sourceFileName,
+      quantity: _validateQuantity(quantity),
+      printWeightG: printWeightG,
+      printDuration: printDuration,
+      sourceType: BatchCostingItemSourceType.manual,
+      printerId: printerId,
+      materialId: materialId,
+      pricingProfileId: pricingProfileId,
+    );
+  }
+
+  factory BatchCostingItem.fromGCodeImport({
+    required String id,
+    required String displayName,
+    required int quantity,
+    required GCodeImportResult importResult,
+    String? sourceFileName,
+    String? sourcePath,
+    String? printerId,
+    String? materialId,
+    String? pricingProfileId,
+  }) {
+    final estimatedDuration = importResult.estimatedDuration;
+    final filamentWeightG = importResult.filamentWeightG;
+    if (estimatedDuration == null) {
+      throw ArgumentError.value(
+        importResult,
+        'importResult',
+        'estimatedDuration must be present',
+      );
+    }
+    if (filamentWeightG == null) {
+      throw ArgumentError.value(
+        importResult,
+        'importResult',
+        'filamentWeightG must be present',
+      );
+    }
+
+    return BatchCostingItem(
+      id: id,
+      displayName: displayName,
+      sourceFileName: sourceFileName,
+      quantity: _validateQuantity(quantity),
+      printWeightG: filamentWeightG,
+      printDuration: estimatedDuration,
+      sourceType: BatchCostingItemSourceType.gcode,
+      importMetadata: BatchCostingImportMetadata(
+        sourceFileName: sourceFileName,
+        sourcePath: sourcePath,
+        slicer: importResult.slicer,
+        hasSafePreview: importResult.hasSafePreview,
+        rawExtractedValues: importResult.rawExtractedValues,
+      ),
+      printerId: printerId,
+      materialId: materialId,
+      pricingProfileId: pricingProfileId,
+    );
+  }
+
+  BatchCostingItem copyWith({
+    String? id,
+    String? displayName,
+    String? sourceFileName,
+    int? quantity,
+    double? printWeightG,
+    Duration? printDuration,
+    BatchCostingItemSourceType? sourceType,
+    BatchCostingImportMetadata? importMetadata,
+    String? printerId,
+    String? materialId,
+    String? pricingProfileId,
+  }) {
+    return BatchCostingItem(
+      id: id ?? this.id,
+      displayName: displayName ?? this.displayName,
+      sourceFileName: sourceFileName ?? this.sourceFileName,
+      quantity: quantity ?? this.quantity,
+      printWeightG: printWeightG ?? this.printWeightG,
+      printDuration: printDuration ?? this.printDuration,
+      sourceType: sourceType ?? this.sourceType,
+      importMetadata: importMetadata ?? this.importMetadata,
+      printerId: printerId ?? this.printerId,
+      materialId: materialId ?? this.materialId,
+      pricingProfileId: pricingProfileId ?? this.pricingProfileId,
+    );
+  }
+
+  static int _validateQuantity(int quantity) {
+    if (quantity < 1) {
+      throw ArgumentError.value(quantity, 'quantity', 'must be >= 1');
+    }
+    return quantity;
+  }
+}

--- a/lib/batch_costing/model/batch_costing_item.dart
+++ b/lib/batch_costing/model/batch_costing_item.dart
@@ -3,13 +3,13 @@ import 'package:threed_print_cost_calculator/gcode_import/gcode_import_result.da
 enum BatchCostingItemSourceType { manual, gcode }
 
 class BatchCostingImportMetadata {
-  const BatchCostingImportMetadata({
+  BatchCostingImportMetadata({
     this.sourceFileName,
     this.sourcePath,
     this.slicer,
     this.hasSafePreview = false,
-    this.rawExtractedValues = const <String, String>{},
-  });
+    Map<String, String> rawExtractedValues = const <String, String>{},
+  }) : rawExtractedValues = Map.unmodifiable(rawExtractedValues);
 
   final String? sourceFileName;
   final String? sourcePath;

--- a/lib/batch_costing/providers/batch_costing_notifier.dart
+++ b/lib/batch_costing/providers/batch_costing_notifier.dart
@@ -19,6 +19,10 @@ class BatchCostingNotifier extends Notifier<BatchCostingState> {
   }
 
   void addItem(BatchCostingItem item) {
+    if (state.items.any((current) => current.id == item.id)) {
+      throw ArgumentError.value(item.id, 'item.id', 'must be unique');
+    }
+
     state = state.copyWith(items: [...state.items, item]);
   }
 

--- a/lib/batch_costing/providers/batch_costing_notifier.dart
+++ b/lib/batch_costing/providers/batch_costing_notifier.dart
@@ -1,0 +1,41 @@
+import 'package:riverpod/riverpod.dart';
+
+import 'package:threed_print_cost_calculator/batch_costing/model/batch_costing_item.dart';
+import 'package:threed_print_cost_calculator/batch_costing/state/batch_costing_state.dart';
+
+final batchCostingProvider =
+    NotifierProvider<BatchCostingNotifier, BatchCostingState>(
+      BatchCostingNotifier.new,
+    );
+
+class BatchCostingNotifier extends Notifier<BatchCostingState> {
+  @override
+  BatchCostingState build() {
+    return BatchCostingState();
+  }
+
+  void reset() {
+    state = BatchCostingState();
+  }
+
+  void addItem(BatchCostingItem item) {
+    state = state.copyWith(items: [...state.items, item]);
+  }
+
+  void updateItem(BatchCostingItem item) {
+    state = state.copyWith(
+      items: [
+        for (final current in state.items)
+          if (current.id == item.id) item else current,
+      ],
+    );
+  }
+
+  void removeItem(String itemId) {
+    state = state.copyWith(
+      items: state.items
+          .where((item) => item.id != itemId)
+          .toList(growable: false),
+    );
+  }
+}

--- a/lib/batch_costing/state/batch_costing_state.dart
+++ b/lib/batch_costing/state/batch_costing_state.dart
@@ -1,0 +1,17 @@
+import 'package:formz/formz.dart';
+
+import 'package:threed_print_cost_calculator/batch_costing/model/batch_costing_item.dart';
+
+class BatchCostingState with FormzMixin {
+  final List<BatchCostingItem> items;
+
+  BatchCostingState({List<BatchCostingItem>? items})
+    : items = List.unmodifiable(items ?? const <BatchCostingItem>[]);
+
+  BatchCostingState copyWith({List<BatchCostingItem>? items}) {
+    return BatchCostingState(items: items ?? this.items);
+  }
+
+  @override
+  List<FormzInput> get inputs => const [];
+}

--- a/test/batch_costing/model/batch_costing_item_test.dart
+++ b/test/batch_costing/model/batch_costing_item_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:threed_print_cost_calculator/batch_costing/model/batch_costing_item.dart';
+import 'package:threed_print_cost_calculator/gcode_import/gcode_import_result.dart';
+
+void main() {
+  test('creates manual batch items with required values', () {
+    final item = BatchCostingItem.manual(
+      id: 'item-1',
+      displayName: 'Benchy',
+      quantity: 2,
+      printWeightG: 34.5,
+      printDuration: const Duration(hours: 1, minutes: 20),
+    );
+
+    expect(item.id, 'item-1');
+    expect(item.displayName, 'Benchy');
+    expect(item.quantity, 2);
+    expect(item.printWeightG, 34.5);
+    expect(item.printDuration, const Duration(hours: 1, minutes: 20));
+    expect(item.sourceType, BatchCostingItemSourceType.manual);
+  });
+
+  test('creates gcode batch items from parsed import values', () {
+    final item = BatchCostingItem.fromGCodeImport(
+      id: 'item-2',
+      displayName: 'benchy.gcode',
+      quantity: 3,
+      importResult: GCodeImportResult(
+        slicer: GCodeSlicer.prusaSlicer,
+        estimatedDuration: const Duration(minutes: 95),
+        filamentLengthMm: 1200,
+        filamentWeightG: 42.7,
+        layerHeightMm: 0.2,
+        previewMetadata: null,
+        previewImageBytes: null,
+        warnings: const [],
+        rawExtractedValues: const {'estimatedDuration': '95m'},
+        hasSafePreview: true,
+      ),
+      sourceFileName: 'benchy.gcode',
+    );
+
+    expect(item.printDuration, const Duration(minutes: 95));
+    expect(item.printWeightG, 42.7);
+    expect(item.sourceType, BatchCostingItemSourceType.gcode);
+    expect(item.importMetadata?.hasSafePreview, isTrue);
+    expect(item.importMetadata?.rawExtractedValues['estimatedDuration'], '95m');
+  });
+
+  test('rejects invalid batch quantities', () {
+    expect(
+      () => BatchCostingItem.manual(
+        id: 'bad',
+        displayName: 'Bad',
+        quantity: 0,
+        printWeightG: 1,
+        printDuration: Duration.zero,
+      ),
+      throwsArgumentError,
+    );
+  });
+}

--- a/test/batch_costing/model/batch_costing_item_test.dart
+++ b/test/batch_costing/model/batch_costing_item_test.dart
@@ -22,6 +22,7 @@ void main() {
   });
 
   test('creates gcode batch items from parsed import values', () {
+    final rawValues = <String, String>{'estimatedDuration': '95m'};
     final item = BatchCostingItem.fromGCodeImport(
       id: 'item-2',
       displayName: 'benchy.gcode',
@@ -35,7 +36,7 @@ void main() {
         previewMetadata: null,
         previewImageBytes: null,
         warnings: const [],
-        rawExtractedValues: const {'estimatedDuration': '95m'},
+        rawExtractedValues: rawValues,
         hasSafePreview: true,
       ),
       sourceFileName: 'benchy.gcode',
@@ -46,6 +47,14 @@ void main() {
     expect(item.sourceType, BatchCostingItemSourceType.gcode);
     expect(item.importMetadata?.hasSafePreview, isTrue);
     expect(item.importMetadata?.rawExtractedValues['estimatedDuration'], '95m');
+
+    final metadata = item.importMetadata!;
+    rawValues['estimatedDuration'] = '100m';
+    expect(metadata.rawExtractedValues['estimatedDuration'], '95m');
+    expect(
+      () => metadata.rawExtractedValues['new'] = 'value',
+      throwsUnsupportedError,
+    );
   });
 
   test('rejects invalid batch quantities', () {

--- a/test/batch_costing/providers/batch_costing_notifier_test.dart
+++ b/test/batch_costing/providers/batch_costing_notifier_test.dart
@@ -23,11 +23,17 @@ void main() {
     notifier.addItem(first);
     expect(container.read(batchCostingProvider).items, [first]);
 
+    expect(() => notifier.addItem(first), throwsArgumentError);
+    expect(container.read(batchCostingProvider).items, [first]);
+
     notifier.updateItem(updated);
     expect(container.read(batchCostingProvider).items.single.quantity, 4);
     expect(container.read(batchCostingProvider).items.single.printWeightG, 60);
 
     notifier.removeItem('item-1');
+    expect(container.read(batchCostingProvider).items, isEmpty);
+
+    notifier.reset();
     expect(container.read(batchCostingProvider).items, isEmpty);
   });
 }

--- a/test/batch_costing/providers/batch_costing_notifier_test.dart
+++ b/test/batch_costing/providers/batch_costing_notifier_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:threed_print_cost_calculator/batch_costing/model/batch_costing_item.dart';
+import 'package:threed_print_cost_calculator/batch_costing/providers/batch_costing_notifier.dart';
+
+void main() {
+  test('adds, updates, and removes batch items', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final notifier = container.read(batchCostingProvider.notifier);
+
+    final first = BatchCostingItem.manual(
+      id: 'item-1',
+      displayName: 'Benchy',
+      quantity: 1,
+      printWeightG: 15,
+      printDuration: const Duration(minutes: 30),
+    );
+    final updated = first.copyWith(quantity: 4, printWeightG: 60);
+
+    notifier.addItem(first);
+    expect(container.read(batchCostingProvider).items, [first]);
+
+    notifier.updateItem(updated);
+    expect(container.read(batchCostingProvider).items.single.quantity, 4);
+    expect(container.read(batchCostingProvider).items.single.printWeightG, 60);
+
+    notifier.removeItem('item-1');
+    expect(container.read(batchCostingProvider).items, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- Add batch costing item domain model with manual and G-code import factories.
- Add batch costing state + Riverpod notifier for add/update/remove/reset.
- Add unit tests for model validation and state mutations.

## Validation
- fvm flutter analyze
- fvm flutter test test/batch_costing/model/batch_costing_item_test.dart test/batch_costing/providers/batch_costing_notifier_test.dart

## Intentionally left out
- Batch costing UI/route work
- Persistence/history/export
- Final batch cost calculation flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch costing with item metadata including import source details, estimated weight and duration, and links to printer/material/pricing profiles.
  * Manual item creation and G-code import flow with import metadata capture.

* **Bug Fixes / Behavior**
  * Quantity validation (must be ≥1) and prevention of duplicate item IDs.
  * Stored import values are isolated and immutable once saved.

* **Tests**
  * Unit tests covering item creation, import mapping, validation, provider add/update/remove/reset behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RemeJuan/threed_print_cost_calculator/pull/73)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->