### PR TITLE
[86c9u8dqt] Batch costing: add/edit/remove manual items from review

### DIFF
--- a/docs/issues/8aeb52bf4fad6628513cae2330651dd6.md
+++ b/docs/issues/8aeb52bf4fad6628513cae2330651dd6.md
@@ -1,24 +1,28 @@
 # Crashlytics: FlutterJNI nativeSurfaceCreated ANR
 
-Status: released
+Status: fixed
 Source: Firebase Crashlytics
 Crashlytics issue ID: 8aeb52bf4fad6628513cae2330651dd6
 First seen: 2.5.0
-Last seen: 2.9.3
-Affected versions: 2.5.0 - 2.9.3
-Affected users: 1
+Last seen: 2.10.0
+Affected versions: 2.5.0 - 2.10.0
+Affected users: 3
 Severity: medium
 
-[View in Firebase Console](https://console.firebase.google.com/project/d-print-cost-calculator-cf650/crashlytics/app/android:com.threed_print_calculator/issues/8aeb52bf4fad6628513cae2330651dd6)
+[View in Firebase Console](https://console.firebase.google.com/project/d-print-cost-calculator-cf650/crashlytics/app/1:476308766683:android:7fc07cf44f4526bc0c31fe/issues/8aeb52bf4fad6628513cae2330651dd6?&time=1778284800000:1778975999000)
 
 ## Summary
 ANR triggered by slow operations in main thread
+
+## Regression Note
+- 2026-05-16: Issue regressed in version 2.10.0 (193). Events: 3, Impacted Users: 3.
 
 ## Investigation log
 - 2026-05-06: Investigation started. Status set to `investigating` during active work.
 - 2026-05-06: Enriched from Crashlytics MCP. Confirmed ANR, Android 12, Google Pixel 6 Pro, 9 events across one impacted user.
 - 2026-05-06: Fix implemented and validated locally. Status set to `fixed`.
-
+- 2026-05-12: Promoted to released.
+- 2026-05-16: REGRESSION DETECTED. Status set back to `investigating`.
 
 ## Stack trace
 - Type: ANR
@@ -41,10 +45,10 @@ ANR triggered by slow operations in main thread
 
 ## Severity & priority
 - Type: ANR
-- Impact: 1 user, 9 events, open across 2.5.0 and 2.9.3
+- Impact: 3 users, 3 events, regressed in 2.10.0
 - Device/OS concentration: Google Pixel 6 Pro, Android 12
 - Surface: app shell / announcement presentation, not calculator data integrity
-- Priority: medium
+- Priority: high (REGRESSED)
 
 ## Reproduction notes
 - No direct local ANR reproduction.
@@ -56,23 +60,22 @@ ANR triggered by slow operations in main thread
 - Patched `AppPage` to present whats-new only when route is current and app lifecycle is resumed.
 
 ## Fix branch/worktree
-- Branch: `fix/crashlytics-8aeb52bf4fad6628513cae2330651dd6-flutterjni-anr`
+- Branch: `fix/crashlytics-8aeb52bf4fad6628513cae2330651dd6-flutterjni-anr-regression`
 
 ## Validation
-- `fvm flutter analyze lib/app/app_page.dart test/app/view/app_page_test.dart test/app/view/app_page_test_support.dart`
 - `fvm flutter test test/app/view/app_page_test.dart --no-pub`
-- `make flutter_test`
-- `fvm flutter analyze` still reports pre-existing unrelated warnings in `lib/materials/csv_import/csv_import_page.dart`, `lib/materials/widgets/material_card.dart`, and `lib/materials/widgets/material_filters.dart`.
+- `fvm flutter analyze`
+- Full suite command not rerun in this pass; previous local validation from the prior fix remains recorded in the issue history.
 
 ## Follow-up
 - Monitor Crashlytics after next Android release for recurrence of `nativeSurfaceCreated` on announcement flows.
-- If repeats continue, add stronger lifecycle deferral for announcements on app resume.
 
 ## Root cause
-- Missing route/lifecycle guard around async whats-new presentation in `lib/app/app_page.dart`.
+- The previous guard was not sufficient for the regression path in 2.10.0 because `whatsNewShown` was still being set before the route/lifecycle check completed, so an async announcement could still race with a route transition and present the sheet from a stale context.
 
 ## Fix summary
-- Added guard so whats-new sheet only presents when `AppPage` route is current and app lifecycle is resumed.
+- Moved the `whatsNewShown` latch to after the route/lifecycle guard and post-frame callback.
+- Added a defensive mounted check and kept the sheet suppressed when `AppPage` is not current or the app is not resumed.
 - Added widget regression test covering async announcement resolution while another route is on top.
 
 ## Risk assessment
@@ -80,7 +83,4 @@ ANR triggered by slow operations in main thread
 - Trade-off: if announcement resolves while another route/activity is active, it is skipped for that session and can appear on a later launch instead.
 
 ## Release
-- Promoted to released on 2026-05-12 by Hermes triage check-in.
-- PR #62 merged: https://github.com/RemeJuan/threed_print_cost_calculator/pull/62
-- Firebase Crashlytics closed upstream on 2026-05-12 by Hermes triage.
-- Kanban task t_83543ac5 already in `done`.
+- Previous release info preserved for context only; this regression is a new 2.10.0 occurrence and has not been released yet.

--- a/docs/product/batch_costing.md
+++ b/docs/product/batch_costing.md
@@ -99,6 +99,8 @@ A dedicated Screen 0 should let the user choose how to start:
 
 Both entry paths should merge into the same batch item review flow.
 
+The batch review screen should let users add more manual items, edit existing items, and remove items before continuing.
+
 ## Expected V1 Flow
 
 1. Entry method
@@ -142,6 +144,7 @@ Manual batch entry captures the same core values normally pulled from G-code:
 - Print duration
 
 Manual entry is for users who already know print weight/time or do not have G-code available.
+The first manual item is created in the earlier setup step; the review screen extends that set.
 
 ## Multi-file G-code Import
 

--- a/docs/product/batch_costing.md
+++ b/docs/product/batch_costing.md
@@ -1,5 +1,7 @@
 # Batch Costing
 
+ClickUp Task: 86c9u8dqt
+
 ## Summary
 
 Batch costing adds a dedicated workflow for quoting multiple prints together without cluttering the existing single-print calculator screen.

--- a/lib/batch_costing/batch_costing_page.dart
+++ b/lib/batch_costing/batch_costing_page.dart
@@ -9,6 +9,7 @@ import 'package:threed_print_cost_calculator/batch_costing/providers/batch_costi
 import 'package:threed_print_cost_calculator/batch_costing/widgets/batch_costing_item_editor_dialog.dart';
 import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
 import 'package:threed_print_cost_calculator/shared/providers/batch_costing_visibility.dart';
+import 'package:threed_print_cost_calculator/core/analytics/app_analytics.dart';
 import 'package:threed_print_cost_calculator/shared/utils/text_input_normalizers.dart';
 import 'package:threed_print_cost_calculator/shared/utils/weight_formatting.dart';
 
@@ -304,18 +305,30 @@ class _BatchCostingPageState extends ConsumerState<BatchCostingPage> {
     );
 
     if (result == null) return;
+    if (!mounted) return;
 
+    final itemId = DateTime.now().microsecondsSinceEpoch.toString();
     ref
         .read(batchCostingProvider.notifier)
         .addItem(
           BatchCostingItem.manual(
-            id: DateTime.now().microsecondsSinceEpoch.toString(),
+            id: itemId,
             displayName: result.displayName,
             quantity: result.quantity,
             printWeightG: result.printWeightG,
             printDuration: result.printDuration,
           ),
         );
+
+    AppAnalytics.safeLog(
+      () => AppAnalytics.batchCostingItemAdded(
+        id: itemId,
+        displayName: result.displayName,
+        quantity: result.quantity,
+        printWeightG: result.printWeightG,
+        printDuration: result.printDuration,
+      ),
+    );
   }
 
   Future<void> _editItem(BuildContext context, BatchCostingItem item) async {
@@ -332,16 +345,26 @@ class _BatchCostingPageState extends ConsumerState<BatchCostingPage> {
     );
 
     if (result == null) return;
+    if (!mounted) return;
 
+    final updatedItem = item.copyWith(
+      displayName: result.displayName,
+      quantity: result.quantity,
+      printWeightG: result.printWeightG,
+      printDuration: result.printDuration,
+    );
     ref
         .read(batchCostingProvider.notifier)
-        .updateItem(
-          item.copyWith(
-            displayName: result.displayName,
-            quantity: result.quantity,
-            printWeightG: result.printWeightG,
-            printDuration: result.printDuration,
-          ),
-        );
+        .updateItem(updatedItem);
+
+    AppAnalytics.safeLog(
+      () => AppAnalytics.batchCostingItemEdited(
+        id: updatedItem.id,
+        displayName: updatedItem.displayName,
+        quantity: updatedItem.quantity,
+        printWeightG: updatedItem.printWeightG,
+        printDuration: updatedItem.printDuration,
+      ),
+    );
   }
 }

--- a/lib/batch_costing/batch_costing_page.dart
+++ b/lib/batch_costing/batch_costing_page.dart
@@ -6,6 +6,7 @@ import 'package:threed_print_cost_calculator/app/components/focus_safe_text_fiel
 import 'package:threed_print_cost_calculator/batch_costing/batch_printer_assignment_page.dart';
 import 'package:threed_print_cost_calculator/batch_costing/model/batch_costing_item.dart';
 import 'package:threed_print_cost_calculator/batch_costing/providers/batch_costing_notifier.dart';
+import 'package:threed_print_cost_calculator/batch_costing/widgets/batch_costing_item_editor_dialog.dart';
 import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
 import 'package:threed_print_cost_calculator/shared/providers/batch_costing_visibility.dart';
 import 'package:threed_print_cost_calculator/shared/utils/text_input_normalizers.dart';
@@ -65,6 +66,15 @@ class _BatchCostingPageState extends ConsumerState<BatchCostingPage> {
               Text(
                 l10n.batchCostingReviewSubtitle,
                 style: Theme.of(context).textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 16),
+              Align(
+                alignment: AlignmentDirectional.centerEnd,
+                child: FilledButton.icon(
+                  onPressed: () => _addManualItem(context),
+                  icon: const Icon(Icons.add),
+                  label: Text(l10n.batchCostingReviewAddManualItemButton),
+                ),
               ),
               const SizedBox(height: 16),
               Expanded(
@@ -174,6 +184,15 @@ class _BatchCostingPageState extends ConsumerState<BatchCostingPage> {
           overflow: TextOverflow.ellipsis,
         ),
         children: [
+          Align(
+            alignment: AlignmentDirectional.centerEnd,
+            child: TextButton.icon(
+              onPressed: () => _editItem(context, item),
+              icon: const Icon(Icons.edit_outlined),
+              label: Text(l10n.editButton),
+            ),
+          ),
+          const SizedBox(height: 8),
           _itemDetailRow(
             context,
             l10n.batchCostingReviewWeightLabel,
@@ -269,5 +288,60 @@ class _BatchCostingPageState extends ConsumerState<BatchCostingPage> {
         builder: (_) => const BatchPrinterAssignmentPage(),
       ),
     );
+  }
+
+  Future<void> _addManualItem(BuildContext context) async {
+    final l10n = AppLocalizations.of(context)!;
+    final result = await showDialog<BatchCostingItemEditorResult>(
+      context: context,
+      builder: (_) => BatchCostingItemEditorDialog(
+        title: l10n.batchCostingItemEditorAddTitle,
+        initialDisplayName: '',
+        initialQuantity: 1,
+        initialPrintWeightG: 1,
+        initialPrintDuration: const Duration(minutes: 1),
+      ),
+    );
+
+    if (result == null) return;
+
+    ref
+        .read(batchCostingProvider.notifier)
+        .addItem(
+          BatchCostingItem.manual(
+            id: DateTime.now().microsecondsSinceEpoch.toString(),
+            displayName: result.displayName,
+            quantity: result.quantity,
+            printWeightG: result.printWeightG,
+            printDuration: result.printDuration,
+          ),
+        );
+  }
+
+  Future<void> _editItem(BuildContext context, BatchCostingItem item) async {
+    final l10n = AppLocalizations.of(context)!;
+    final result = await showDialog<BatchCostingItemEditorResult>(
+      context: context,
+      builder: (_) => BatchCostingItemEditorDialog(
+        title: l10n.batchCostingItemEditorEditTitle,
+        initialDisplayName: item.displayName,
+        initialQuantity: item.quantity,
+        initialPrintWeightG: item.printWeightG,
+        initialPrintDuration: item.printDuration,
+      ),
+    );
+
+    if (result == null) return;
+
+    ref
+        .read(batchCostingProvider.notifier)
+        .updateItem(
+          item.copyWith(
+            displayName: result.displayName,
+            quantity: result.quantity,
+            printWeightG: result.printWeightG,
+            printDuration: result.printDuration,
+          ),
+        );
   }
 }

--- a/lib/batch_costing/widgets/batch_costing_item_editor_dialog.dart
+++ b/lib/batch_costing/widgets/batch_costing_item_editor_dialog.dart
@@ -1,0 +1,318 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
+import 'package:threed_print_cost_calculator/shared/utils/text_input_normalizers.dart';
+
+class BatchCostingItemEditorResult {
+  const BatchCostingItemEditorResult({
+    required this.displayName,
+    required this.quantity,
+    required this.printWeightG,
+    required this.printDuration,
+  });
+
+  final String displayName;
+  final int quantity;
+  final double printWeightG;
+  final Duration printDuration;
+}
+
+class BatchCostingItemEditorDialog extends StatefulWidget {
+  const BatchCostingItemEditorDialog({
+    required this.title,
+    required this.initialDisplayName,
+    required this.initialQuantity,
+    required this.initialPrintWeightG,
+    required this.initialPrintDuration,
+    super.key,
+  });
+
+  final String title;
+  final String initialDisplayName;
+  final int initialQuantity;
+  final double initialPrintWeightG;
+  final Duration initialPrintDuration;
+
+  @override
+  State<BatchCostingItemEditorDialog> createState() =>
+      _BatchCostingItemEditorDialogState();
+}
+
+class _BatchCostingItemEditorDialogState
+    extends State<BatchCostingItemEditorDialog> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _displayNameController;
+  late final TextEditingController _quantityController;
+  late final TextEditingController _printWeightController;
+  late final TextEditingController _durationHoursController;
+  late final TextEditingController _durationMinutesController;
+  late final FocusNode _displayNameFocusNode;
+  late final FocusNode _quantityFocusNode;
+  late final FocusNode _printWeightFocusNode;
+  late final FocusNode _durationHoursFocusNode;
+  late final FocusNode _durationMinutesFocusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _displayNameController = TextEditingController(
+      text: widget.initialDisplayName,
+    );
+    _quantityController = TextEditingController(
+      text: widget.initialQuantity.toString(),
+    );
+    _printWeightController = TextEditingController(
+      text: widget.initialPrintWeightG.toString().replaceFirst(
+        RegExp(r'\.0$'),
+        '',
+      ),
+    );
+    _durationHoursController = TextEditingController(
+      text: widget.initialPrintDuration.inHours.toString(),
+    );
+    _durationMinutesController = TextEditingController(
+      text: widget.initialPrintDuration.inMinutes.remainder(60).toString(),
+    );
+    _displayNameFocusNode = FocusNode();
+    _quantityFocusNode = FocusNode();
+    _printWeightFocusNode = FocusNode();
+    _durationHoursFocusNode = FocusNode();
+    _durationMinutesFocusNode = FocusNode();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _displayNameFocusNode.requestFocus();
+    });
+  }
+
+  @override
+  void dispose() {
+    _displayNameController.dispose();
+    _quantityController.dispose();
+    _printWeightController.dispose();
+    _durationHoursController.dispose();
+    _durationMinutesController.dispose();
+    _displayNameFocusNode.dispose();
+    _quantityFocusNode.dispose();
+    _printWeightFocusNode.dispose();
+    _durationHoursFocusNode.dispose();
+    _durationMinutesFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    return AlertDialog(
+      title: Text(widget.title),
+      content: Form(
+        key: _formKey,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextFormField(
+                key: const ValueKey<String>('batch-costing-item-name'),
+                controller: _displayNameController,
+                focusNode: _displayNameFocusNode,
+                textInputAction: TextInputAction.next,
+                decoration: InputDecoration(
+                  labelText: l10n.batchCostingItemNameLabel,
+                  hintText: l10n.printNameHint,
+                ),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return l10n.csvNameRequiredError;
+                  }
+                  return null;
+                },
+                onFieldSubmitted: (_) => _quantityFocusNode.requestFocus(),
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                key: const ValueKey<String>('batch-costing-item-quantity'),
+                controller: _quantityController,
+                focusNode: _quantityFocusNode,
+                keyboardType: TextInputType.number,
+                textInputAction: TextInputAction.next,
+                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                decoration: InputDecoration(
+                  labelText: l10n.batchCostingReviewQuantityLabel,
+                ),
+                validator: (value) {
+                  final quantity = int.tryParse(value ?? '');
+                  if (quantity == null || quantity < 1) {
+                    return l10n.invalidNumber;
+                  }
+                  return null;
+                },
+                onFieldSubmitted: (_) => _printWeightFocusNode.requestFocus(),
+                onChanged: (_) => _normalizeIntegerController(
+                  _quantityController,
+                  allowDecimal: false,
+                ),
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                key: const ValueKey<String>('batch-costing-item-weight'),
+                controller: _printWeightController,
+                focusNode: _printWeightFocusNode,
+                keyboardType: const TextInputType.numberWithOptions(
+                  decimal: true,
+                ),
+                textInputAction: TextInputAction.next,
+                inputFormatters: [
+                  FilteringTextInputFormatter.allow(RegExp(r'[\d\.,]')),
+                ],
+                decoration: InputDecoration(
+                  labelText: l10n.printWeightLabel,
+                  suffixText: l10n.gramsSuffix,
+                ),
+                validator: (value) {
+                  final parsed = _parseDouble(value);
+                  if (parsed == null || parsed <= 0) {
+                    return l10n.invalidNumber;
+                  }
+                  return null;
+                },
+                onFieldSubmitted: (_) => _durationHoursFocusNode.requestFocus(),
+                onChanged: (_) => _normalizeWeightController(),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                    child: TextFormField(
+                      key: const ValueKey<String>(
+                        'batch-costing-item-duration-hours',
+                      ),
+                      controller: _durationHoursController,
+                      focusNode: _durationHoursFocusNode,
+                      keyboardType: TextInputType.number,
+                      textInputAction: TextInputAction.next,
+                      inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                      decoration: InputDecoration(
+                        labelText: l10n.durationHoursLabel,
+                      ),
+                      validator: (value) {
+                        final hours = int.tryParse(value ?? '');
+                        if (hours == null || hours < 0) {
+                          return l10n.invalidNumber;
+                        }
+                        return null;
+                      },
+                      onFieldSubmitted: (_) =>
+                          _durationMinutesFocusNode.requestFocus(),
+                      onChanged: (_) => _normalizeIntegerController(
+                        _durationHoursController,
+                        allowDecimal: false,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: TextFormField(
+                      key: const ValueKey<String>(
+                        'batch-costing-item-duration-minutes',
+                      ),
+                      controller: _durationMinutesController,
+                      focusNode: _durationMinutesFocusNode,
+                      keyboardType: TextInputType.number,
+                      textInputAction: TextInputAction.done,
+                      inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                      decoration: InputDecoration(
+                        labelText: l10n.durationMinutesLabel,
+                      ),
+                      validator: (value) {
+                        final minutes = int.tryParse(value ?? '');
+                        if (minutes == null || minutes < 0 || minutes > 59) {
+                          return l10n.invalidNumber;
+                        }
+                        return null;
+                      },
+                      onFieldSubmitted: (_) => _save(context),
+                      onChanged: (_) => _normalizeIntegerController(
+                        _durationMinutesController,
+                        allowDecimal: false,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(MaterialLocalizations.of(context).cancelButtonLabel),
+        ),
+        FilledButton(
+          key: const ValueKey<String>('batch-costing-item-editor-save'),
+          onPressed: () => _save(context),
+          child: Text(l10n.saveButton),
+        ),
+      ],
+    );
+  }
+
+  void _normalizeIntegerController(
+    TextEditingController controller, {
+    required bool allowDecimal,
+  }) {
+    final normalized = normalizeLeadingZeroNumericInput(
+      controller.text,
+      allowDecimal: allowDecimal,
+    );
+    if (normalized == controller.text) return;
+
+    controller.value = TextEditingValue(
+      text: normalized,
+      selection: TextSelection.collapsed(offset: normalized.length),
+      composing: TextRange.empty,
+    );
+  }
+
+  void _normalizeWeightController() {
+    final normalized = normalizeLeadingZeroNumericInput(
+      _printWeightController.text,
+      allowDecimal: true,
+    );
+    if (normalized == _printWeightController.text) return;
+
+    _printWeightController.value = TextEditingValue(
+      text: normalized,
+      selection: TextSelection.collapsed(offset: normalized.length),
+      composing: TextRange.empty,
+    );
+  }
+
+  double? _parseDouble(String? value) {
+    final normalized = value?.replaceAll(',', '.');
+    return double.tryParse(normalized ?? '');
+  }
+
+  void _save(BuildContext context) {
+    if (!(_formKey.currentState?.validate() ?? false)) {
+      return;
+    }
+
+    final quantity = int.parse(_quantityController.text);
+    final printWeightG = _parseDouble(_printWeightController.text)!;
+    final duration = Duration(
+      hours: int.parse(_durationHoursController.text),
+      minutes: int.parse(_durationMinutesController.text),
+    );
+
+    Navigator.of(context).pop(
+      BatchCostingItemEditorResult(
+        displayName: _displayNameController.text.trim(),
+        quantity: quantity,
+        printWeightG: printWeightG,
+        printDuration: duration,
+      ),
+    );
+  }
+}

--- a/lib/core/analytics/app_analytics.dart
+++ b/lib/core/analytics/app_analytics.dart
@@ -704,6 +704,44 @@ class AppAnalytics {
     );
   }
 
+  static Future<void> batchCostingItemAdded({
+    required String id,
+    required String displayName,
+    required int quantity,
+    required double printWeightG,
+    required Duration printDuration,
+  }) {
+    return log(
+      'batch_costing_item_added',
+      params: {
+        'item_id': id,
+        'display_name': displayName,
+        'quantity': quantity,
+        'print_weight_g': printWeightG,
+        'print_duration_min': printDuration.inMinutes,
+      },
+    );
+  }
+
+  static Future<void> batchCostingItemEdited({
+    required String id,
+    required String displayName,
+    required int quantity,
+    required double printWeightG,
+    required Duration printDuration,
+  }) {
+    return log(
+      'batch_costing_item_edited',
+      params: {
+        'item_id': id,
+        'display_name': displayName,
+        'quantity': quantity,
+        'print_weight_g': printWeightG,
+        'print_duration_min': printDuration.inMinutes,
+      },
+    );
+  }
+
   static void safeLog(Future<void> Function() callback) {
     unawaited(callback());
   }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2207,6 +2207,12 @@ abstract class AppLocalizations {
   /// **'Review batch items before printer assignment.'**
   String get batchCostingReviewSubtitle;
 
+  /// No description provided for @batchCostingReviewAddManualItemButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Add manual item'**
+  String get batchCostingReviewAddManualItemButton;
+
   /// No description provided for @batchCostingReviewEmptyTitle.
   ///
   /// In en, this message translates to:
@@ -2272,6 +2278,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Duration'**
   String get batchCostingReviewDurationLabel;
+
+  /// No description provided for @batchCostingItemEditorAddTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add manual item'**
+  String get batchCostingItemEditorAddTitle;
+
+  /// No description provided for @batchCostingItemEditorEditTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit batch item'**
+  String get batchCostingItemEditorEditTitle;
+
+  /// No description provided for @batchCostingItemNameLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Item / model name'**
+  String get batchCostingItemNameLabel;
 
   /// No description provided for @batchCostingPrinterAssignmentAppBarTitle.
   ///

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1170,6 +1170,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Batch-Artikel vor Druckerzuweisung prüfen.';
 
   @override
+  String get batchCostingReviewAddManualItemButton =>
+      'Manuellen Artikel hinzufügen';
+
+  @override
   String get batchCostingReviewEmptyTitle => 'Noch keine Batch-Artikel';
 
   @override
@@ -1202,6 +1206,15 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get batchCostingReviewDurationLabel => 'Dauer';
+
+  @override
+  String get batchCostingItemEditorAddTitle => 'Manuellen Artikel hinzufügen';
+
+  @override
+  String get batchCostingItemEditorEditTitle => 'Batch-Artikel bearbeiten';
+
+  @override
+  String get batchCostingItemNameLabel => 'Artikel-/Modellname';
 
   @override
   String get batchCostingPrinterAssignmentAppBarTitle => 'Druckerzuweisung';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1159,6 +1159,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Review batch items before printer assignment.';
 
   @override
+  String get batchCostingReviewAddManualItemButton => 'Add manual item';
+
+  @override
   String get batchCostingReviewEmptyTitle => 'No batch items yet';
 
   @override
@@ -1192,6 +1195,15 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get batchCostingReviewDurationLabel => 'Duration';
+
+  @override
+  String get batchCostingItemEditorAddTitle => 'Add manual item';
+
+  @override
+  String get batchCostingItemEditorEditTitle => 'Edit batch item';
+
+  @override
+  String get batchCostingItemNameLabel => 'Item / model name';
 
   @override
   String get batchCostingPrinterAssignmentAppBarTitle => 'Printer assignment';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1174,6 +1174,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'Revise los artículos del lote antes de asignar impresora.';
 
   @override
+  String get batchCostingReviewAddManualItemButton => 'Añadir artículo manual';
+
+  @override
   String get batchCostingReviewEmptyTitle => 'Aún no hay artículos en lote';
 
   @override
@@ -1207,6 +1210,15 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get batchCostingReviewDurationLabel => 'Duración';
+
+  @override
+  String get batchCostingItemEditorAddTitle => 'Añadir artículo manual';
+
+  @override
+  String get batchCostingItemEditorEditTitle => 'Editar artículo del lote';
+
+  @override
+  String get batchCostingItemNameLabel => 'Nombre del artículo/modelo';
 
   @override
   String get batchCostingPrinterAssignmentAppBarTitle =>

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1183,6 +1183,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Vérifiez les articles du lot avant l\'attribution de l\'imprimante.';
 
   @override
+  String get batchCostingReviewAddManualItemButton =>
+      'Ajouter un article manuel';
+
+  @override
   String get batchCostingReviewEmptyTitle =>
       'Aucun article de lot pour l\'instant';
 
@@ -1217,6 +1221,15 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get batchCostingReviewDurationLabel => 'Durée';
+
+  @override
+  String get batchCostingItemEditorAddTitle => 'Ajouter un article manuel';
+
+  @override
+  String get batchCostingItemEditorEditTitle => 'Modifier l\'article du lot';
+
+  @override
+  String get batchCostingItemNameLabel => 'Nom de l\'article / du modèle';
 
   @override
   String get batchCostingPrinterAssignmentAppBarTitle =>

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -1158,6 +1158,9 @@ class AppLocalizationsId extends AppLocalizations {
       'Tinjau item batch sebelum penugasan printer.';
 
   @override
+  String get batchCostingReviewAddManualItemButton => 'Tambah item manual';
+
+  @override
   String get batchCostingReviewEmptyTitle => 'Belum ada item batch';
 
   @override
@@ -1191,6 +1194,15 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get batchCostingReviewDurationLabel => 'Durasi';
+
+  @override
+  String get batchCostingItemEditorAddTitle => 'Tambah item manual';
+
+  @override
+  String get batchCostingItemEditorEditTitle => 'Edit item batch';
+
+  @override
+  String get batchCostingItemNameLabel => 'Nama item / model';
 
   @override
   String get batchCostingPrinterAssignmentAppBarTitle => 'Penugasan printer';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1177,6 +1177,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Rivedi gli articoli batch prima dell\'assegnazione stampante.';
 
   @override
+  String get batchCostingReviewAddManualItemButton =>
+      'Aggiungi articolo manuale';
+
+  @override
   String get batchCostingReviewEmptyTitle => 'Nessun articolo batch ancora';
 
   @override
@@ -1210,6 +1214,15 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get batchCostingReviewDurationLabel => 'Durata';
+
+  @override
+  String get batchCostingItemEditorAddTitle => 'Aggiungi articolo manuale';
+
+  @override
+  String get batchCostingItemEditorEditTitle => 'Modifica articolo batch';
+
+  @override
+  String get batchCostingItemNameLabel => 'Nome articolo / modello';
 
   @override
   String get batchCostingPrinterAssignmentAppBarTitle =>

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1133,6 +1133,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get batchCostingReviewSubtitle => 'プリンター割り当て前にバッチアイテムを確認します。';
 
   @override
+  String get batchCostingReviewAddManualItemButton => '手動アイテムを追加';
+
+  @override
   String get batchCostingReviewEmptyTitle => 'まだバッチアイテムがありません';
 
   @override
@@ -1164,6 +1167,15 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get batchCostingReviewDurationLabel => '時間';
+
+  @override
+  String get batchCostingItemEditorAddTitle => '手動アイテムを追加';
+
+  @override
+  String get batchCostingItemEditorEditTitle => 'バッチアイテムを編集';
+
+  @override
+  String get batchCostingItemNameLabel => 'アイテム / モデル名';
 
   @override
   String get batchCostingPrinterAssignmentAppBarTitle => 'プリンター割り当て';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1169,6 +1169,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Beoordeel batch-artikelen vóór printertoewijzing.';
 
   @override
+  String get batchCostingReviewAddManualItemButton =>
+      'Handmatig item toevoegen';
+
+  @override
   String get batchCostingReviewEmptyTitle => 'Nog geen batch-artikelen';
 
   @override
@@ -1202,6 +1206,15 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get batchCostingReviewDurationLabel => 'Duur';
+
+  @override
+  String get batchCostingItemEditorAddTitle => 'Handmatig item toevoegen';
+
+  @override
+  String get batchCostingItemEditorEditTitle => 'Batch-item bewerken';
+
+  @override
+  String get batchCostingItemNameLabel => 'Item-/modelnaam';
 
   @override
   String get batchCostingPrinterAssignmentAppBarTitle => 'Printertoewijzing';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1171,6 +1171,9 @@ class AppLocalizationsPt extends AppLocalizations {
       'Revise os itens do lote antes da atribuição de impressora.';
 
   @override
+  String get batchCostingReviewAddManualItemButton => 'Adicionar item manual';
+
+  @override
   String get batchCostingReviewEmptyTitle => 'Nenhum item de lote ainda';
 
   @override
@@ -1204,6 +1207,15 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get batchCostingReviewDurationLabel => 'Duração';
+
+  @override
+  String get batchCostingItemEditorAddTitle => 'Adicionar item manual';
+
+  @override
+  String get batchCostingItemEditorEditTitle => 'Editar item do lote';
+
+  @override
+  String get batchCostingItemNameLabel => 'Nome do item / modelo';
 
   @override
   String get batchCostingPrinterAssignmentAppBarTitle =>

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -1148,6 +1148,9 @@ class AppLocalizationsTh extends AppLocalizations {
       'ตรวจสอบรายการชุดก่อนกำหนดเครื่องพิมพ์';
 
   @override
+  String get batchCostingReviewAddManualItemButton => 'เพิ่มรายการด้วยตนเอง';
+
+  @override
   String get batchCostingReviewEmptyTitle => 'ยังไม่มีรายการชุด';
 
   @override
@@ -1181,6 +1184,15 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get batchCostingReviewDurationLabel => 'ระยะเวลา';
+
+  @override
+  String get batchCostingItemEditorAddTitle => 'เพิ่มรายการด้วยตนเอง';
+
+  @override
+  String get batchCostingItemEditorEditTitle => 'แก้ไขรายการชุด';
+
+  @override
+  String get batchCostingItemNameLabel => 'ชื่อรายการ / รุ่น';
 
   @override
   String get batchCostingPrinterAssignmentAppBarTitle => 'กำหนดเครื่องพิมพ์';

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -575,6 +575,7 @@
   "stockBadgeNoTracking": "Keine Verfolgung",
   "batchCostingReviewAppBarTitle": "Batch-Artikelprüfung",
   "batchCostingReviewSubtitle": "Batch-Artikel vor Druckerzuweisung prüfen.",
+  "batchCostingReviewAddManualItemButton": "Manuellen Artikel hinzufügen",
   "batchCostingReviewEmptyTitle": "Noch keine Batch-Artikel",
   "batchCostingReviewEmptyBody": "Importierte oder manuelle Drucke hinzufügen.",
   "batchCostingReviewContinueButton": "Weiter zur Druckerzuweisung",
@@ -586,6 +587,9 @@
   "batchCostingReviewSourceUnknown": "Unbekannt",
   "batchCostingReviewWeightLabel": "Gewicht",
   "batchCostingReviewDurationLabel": "Dauer",
+  "batchCostingItemEditorAddTitle": "Manuellen Artikel hinzufügen",
+  "batchCostingItemEditorEditTitle": "Batch-Artikel bearbeiten",
+  "batchCostingItemNameLabel": "Artikel-/Modellname",
   "batchCostingPrinterAssignmentAppBarTitle": "Druckerzuweisung",
   "batchCostingPrinterAssignmentSubtitle": "Die Druckerzuweisung wird im nächsten Batch-Costing-Schritt fortgesetzt."
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -503,6 +503,7 @@
   "stockBadgeNoTracking": "No tracking",
   "batchCostingReviewAppBarTitle": "Batch item review",
   "batchCostingReviewSubtitle": "Review batch items before printer assignment.",
+  "batchCostingReviewAddManualItemButton": "Add manual item",
   "batchCostingReviewEmptyTitle": "No batch items yet",
   "batchCostingReviewEmptyBody": "Add imported or manual prints to continue.",
   "batchCostingReviewContinueButton": "Continue to printer assignment",
@@ -514,6 +515,9 @@
   "batchCostingReviewSourceUnknown": "Unknown",
   "batchCostingReviewWeightLabel": "Weight",
   "batchCostingReviewDurationLabel": "Duration",
+  "batchCostingItemEditorAddTitle": "Add manual item",
+  "batchCostingItemEditorEditTitle": "Edit batch item",
+  "batchCostingItemNameLabel": "Item / model name",
   "batchCostingPrinterAssignmentAppBarTitle": "Printer assignment",
   "batchCostingPrinterAssignmentSubtitle": "Printer assignment continues in the next batch costing step."
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -574,6 +574,7 @@
   "stockBadgeNoTracking": "Sin seguimiento",
   "batchCostingReviewAppBarTitle": "Revisión de lotes",
   "batchCostingReviewSubtitle": "Revise los artículos del lote antes de asignar impresora.",
+  "batchCostingReviewAddManualItemButton": "Añadir artículo manual",
   "batchCostingReviewEmptyTitle": "Aún no hay artículos en lote",
   "batchCostingReviewEmptyBody": "Añada impresiones importadas o manuales para continuar.",
   "batchCostingReviewContinueButton": "Continuar a asignación de impresora",
@@ -585,6 +586,9 @@
   "batchCostingReviewSourceUnknown": "Desconocido",
   "batchCostingReviewWeightLabel": "Peso",
   "batchCostingReviewDurationLabel": "Duración",
+  "batchCostingItemEditorAddTitle": "Añadir artículo manual",
+  "batchCostingItemEditorEditTitle": "Editar artículo del lote",
+  "batchCostingItemNameLabel": "Nombre del artículo/modelo",
   "batchCostingPrinterAssignmentAppBarTitle": "Asignación de impresora",
   "batchCostingPrinterAssignmentSubtitle": "La asignación de impresora continúa en el siguiente paso."
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -577,6 +577,7 @@
   "stockBadgeNoTracking": "Non suivi",
   "batchCostingReviewAppBarTitle": "Vérification des lots",
   "batchCostingReviewSubtitle": "Vérifiez les articles du lot avant l'attribution de l'imprimante.",
+  "batchCostingReviewAddManualItemButton": "Ajouter un article manuel",
   "batchCostingReviewEmptyTitle": "Aucun article de lot pour l'instant",
   "batchCostingReviewEmptyBody": "Ajoutez des impressions importées ou manuelles pour continuer.",
   "batchCostingReviewContinueButton": "Continuer vers l'attribution de l'imprimante",
@@ -588,6 +589,9 @@
   "batchCostingReviewSourceUnknown": "Inconnu",
   "batchCostingReviewWeightLabel": "Poids",
   "batchCostingReviewDurationLabel": "Durée",
+  "batchCostingItemEditorAddTitle": "Ajouter un article manuel",
+  "batchCostingItemEditorEditTitle": "Modifier l'article du lot",
+  "batchCostingItemNameLabel": "Nom de l'article / du modèle",
   "batchCostingPrinterAssignmentAppBarTitle": "Attribution de l'imprimante",
   "batchCostingPrinterAssignmentSubtitle": "L'attribution de l'imprimante continue à l'étape suivante."
 }

--- a/lib/l10n/intl_id.arb
+++ b/lib/l10n/intl_id.arb
@@ -575,6 +575,7 @@
   "stockBadgeNoTracking": "Tidak dilacak",
   "batchCostingReviewAppBarTitle": "Tinjauan item batch",
   "batchCostingReviewSubtitle": "Tinjau item batch sebelum penugasan printer.",
+  "batchCostingReviewAddManualItemButton": "Tambah item manual",
   "batchCostingReviewEmptyTitle": "Belum ada item batch",
   "batchCostingReviewEmptyBody": "Tambahkan cetakan impor atau manual untuk melanjutkan.",
   "batchCostingReviewContinueButton": "Lanjutkan ke penugasan printer",
@@ -586,6 +587,9 @@
   "batchCostingReviewSourceUnknown": "Tidak diketahui",
   "batchCostingReviewWeightLabel": "Berat",
   "batchCostingReviewDurationLabel": "Durasi",
+  "batchCostingItemEditorAddTitle": "Tambah item manual",
+  "batchCostingItemEditorEditTitle": "Edit item batch",
+  "batchCostingItemNameLabel": "Nama item / model",
   "batchCostingPrinterAssignmentAppBarTitle": "Penugasan printer",
   "batchCostingPrinterAssignmentSubtitle": "Penugasan printer berlanjut di langkah batch costing berikutnya."
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -575,6 +575,7 @@
   "stockBadgeNoTracking": "Non tracciato",
   "batchCostingReviewAppBarTitle": "Revisione articoli batch",
   "batchCostingReviewSubtitle": "Rivedi gli articoli batch prima dell'assegnazione stampante.",
+  "batchCostingReviewAddManualItemButton": "Aggiungi articolo manuale",
   "batchCostingReviewEmptyTitle": "Nessun articolo batch ancora",
   "batchCostingReviewEmptyBody": "Aggiungi stampe importate o manuali per continuare.",
   "batchCostingReviewContinueButton": "Continua all'assegnazione stampante",
@@ -586,6 +587,9 @@
   "batchCostingReviewSourceUnknown": "Sconosciuto",
   "batchCostingReviewWeightLabel": "Peso",
   "batchCostingReviewDurationLabel": "Durata",
+  "batchCostingItemEditorAddTitle": "Aggiungi articolo manuale",
+  "batchCostingItemEditorEditTitle": "Modifica articolo batch",
+  "batchCostingItemNameLabel": "Nome articolo / modello",
   "batchCostingPrinterAssignmentAppBarTitle": "Assegnazione stampante",
   "batchCostingPrinterAssignmentSubtitle": "L'assegnazione stampante continua nel prossimo passaggio."
 }

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -576,6 +576,7 @@
   "stockBadgeNoTracking": "追跡なし",
   "batchCostingReviewAppBarTitle": "バッチアイテムレビュー",
   "batchCostingReviewSubtitle": "プリンター割り当て前にバッチアイテムを確認します。",
+  "batchCostingReviewAddManualItemButton": "手動アイテムを追加",
   "batchCostingReviewEmptyTitle": "まだバッチアイテムがありません",
   "batchCostingReviewEmptyBody": "インポートまたは手動のプリントを追加して続行します。",
   "batchCostingReviewContinueButton": "プリンター割り当てに進む",
@@ -587,6 +588,9 @@
   "batchCostingReviewSourceUnknown": "不明",
   "batchCostingReviewWeightLabel": "重量",
   "batchCostingReviewDurationLabel": "時間",
+  "batchCostingItemEditorAddTitle": "手動アイテムを追加",
+  "batchCostingItemEditorEditTitle": "バッチアイテムを編集",
+  "batchCostingItemNameLabel": "アイテム / モデル名",
   "batchCostingPrinterAssignmentAppBarTitle": "プリンター割り当て",
   "batchCostingPrinterAssignmentSubtitle": "プリンター割り当ては次のバッチコスト計算ステップで続行されます。"
 }

--- a/lib/l10n/intl_nl.arb
+++ b/lib/l10n/intl_nl.arb
@@ -576,6 +576,7 @@
   "stockBadgeNoTracking": "Niet bijgehouden",
   "batchCostingReviewAppBarTitle": "Batch-artikelbeoordeling",
   "batchCostingReviewSubtitle": "Beoordeel batch-artikelen vóór printertoewijzing.",
+  "batchCostingReviewAddManualItemButton": "Handmatig item toevoegen",
   "batchCostingReviewEmptyTitle": "Nog geen batch-artikelen",
   "batchCostingReviewEmptyBody": "Voeg geïmporteerde of handmatige afdrukken toe om door te gaan.",
   "batchCostingReviewContinueButton": "Doorgaan naar printertoewijzing",
@@ -587,6 +588,9 @@
   "batchCostingReviewSourceUnknown": "Onbekend",
   "batchCostingReviewWeightLabel": "Gewicht",
   "batchCostingReviewDurationLabel": "Duur",
+  "batchCostingItemEditorAddTitle": "Handmatig item toevoegen",
+  "batchCostingItemEditorEditTitle": "Batch-item bewerken",
+  "batchCostingItemNameLabel": "Item-/modelnaam",
   "batchCostingPrinterAssignmentAppBarTitle": "Printertoewijzing",
   "batchCostingPrinterAssignmentSubtitle": "Printertoewijzing gaat verder in de volgende batch-costing stap."
 }

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -576,6 +576,7 @@
   "stockBadgeNoTracking": "Sem rastreio",
   "batchCostingReviewAppBarTitle": "Revisão de itens do lote",
   "batchCostingReviewSubtitle": "Revise os itens do lote antes da atribuição de impressora.",
+  "batchCostingReviewAddManualItemButton": "Adicionar item manual",
   "batchCostingReviewEmptyTitle": "Nenhum item de lote ainda",
   "batchCostingReviewEmptyBody": "Adicione impressões importadas ou manuais para continuar.",
   "batchCostingReviewContinueButton": "Continuar para atribuição de impressora",
@@ -587,6 +588,9 @@
   "batchCostingReviewSourceUnknown": "Desconhecido",
   "batchCostingReviewWeightLabel": "Peso",
   "batchCostingReviewDurationLabel": "Duração",
+  "batchCostingItemEditorAddTitle": "Adicionar item manual",
+  "batchCostingItemEditorEditTitle": "Editar item do lote",
+  "batchCostingItemNameLabel": "Nome do item / modelo",
   "batchCostingPrinterAssignmentAppBarTitle": "Atribuição de impressora",
   "batchCostingPrinterAssignmentSubtitle": "A atribuição de impressora continua na próxima etapa."
 }

--- a/lib/l10n/intl_th.arb
+++ b/lib/l10n/intl_th.arb
@@ -576,6 +576,7 @@
   "stockBadgeNoTracking": "ไม่ติดตาม",
   "batchCostingReviewAppBarTitle": "ตรวจสอบรายการชุด",
   "batchCostingReviewSubtitle": "ตรวจสอบรายการชุดก่อนกำหนดเครื่องพิมพ์",
+  "batchCostingReviewAddManualItemButton": "เพิ่มรายการด้วยตนเอง",
   "batchCostingReviewEmptyTitle": "ยังไม่มีรายการชุด",
   "batchCostingReviewEmptyBody": "เพิ่มงานพิมพ์ที่นำเข้าหรือด้วยตนเองเพื่อดำเนินการต่อ",
   "batchCostingReviewContinueButton": "ดำเนินการต่อเพื่อกำหนดเครื่องพิมพ์",
@@ -587,6 +588,9 @@
   "batchCostingReviewSourceUnknown": "ไม่ทราบ",
   "batchCostingReviewWeightLabel": "น้ำหนัก",
   "batchCostingReviewDurationLabel": "ระยะเวลา",
+  "batchCostingItemEditorAddTitle": "เพิ่มรายการด้วยตนเอง",
+  "batchCostingItemEditorEditTitle": "แก้ไขรายการชุด",
+  "batchCostingItemNameLabel": "ชื่อรายการ / รุ่น",
   "batchCostingPrinterAssignmentAppBarTitle": "กำหนดเครื่องพิมพ์",
   "batchCostingPrinterAssignmentSubtitle": "การกำหนดเครื่องพิมพ์จะดำเนินการต่อในขั้นตอนถัดไป"
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: threed_print_cost_calculator
 description: A simple 3D Print cost calculator.
-version: 2.10.0+4
+version: 2.10.0+5
 publish_to: none
 
 environment:

--- a/test/batch_costing/batch_costing_page_test.dart
+++ b/test/batch_costing/batch_costing_page_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -36,7 +37,9 @@ void main() {
     );
 
     await tester.pumpApp(const BatchCostingPage(), [
-      batchCostingProvider.overrideWith(() => _FakeBatchCostingNotifier(item)),
+      batchCostingProvider.overrideWith(
+        () => _FakeBatchCostingNotifier([item]),
+      ),
     ]);
 
     final l10n = AppLocalizations.of(
@@ -58,15 +61,158 @@ void main() {
     expect(find.text(l10n.batchCostingReviewEmptyTitle), findsOneWidget);
     expect(find.text('Benchy'), findsNothing);
   });
+
+  testWidgets('adds edits and removes manual items', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      batchCostingEnabledPreferenceKey: true,
+    });
+
+    await tester.pumpApp(const BatchCostingPage(), [
+      batchCostingProvider.overrideWith(
+        () => _FakeBatchCostingNotifier(const <BatchCostingItem>[]),
+      ),
+    ]);
+
+    final l10n = AppLocalizations.of(
+      tester.element(find.byType(BatchCostingPage)),
+    )!;
+
+    await tester.tap(find.text(l10n.batchCostingReviewAddManualItemButton));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('batch-costing-item-name')),
+      'Benchy',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('batch-costing-item-quantity')),
+      '2',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('batch-costing-item-weight')),
+      '34.5',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('batch-costing-item-duration-hours')),
+      '1',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('batch-costing-item-duration-minutes')),
+      '20',
+    );
+    await tester.tap(find.text(l10n.saveButton));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Benchy'), findsOneWidget);
+
+    await tester.tap(find.text('Benchy'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(l10n.editButton).last);
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('batch-costing-item-name')),
+      'Benchy v2',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('batch-costing-item-quantity')),
+      '3',
+    );
+    await tester.tap(find.text(l10n.saveButton));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Benchy v2'), findsOneWidget);
+
+    await tester.tap(find.text(l10n.batchCostingReviewRemoveButton));
+    await tester.pumpAndSettle();
+
+    expect(find.text(l10n.batchCostingReviewEmptyTitle), findsOneWidget);
+    expect(find.text(l10n.batchCostingReviewContinueButton), findsNothing);
+  });
+
+  testWidgets('validates add and edit forms', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      batchCostingEnabledPreferenceKey: true,
+    });
+
+    await tester.pumpApp(const BatchCostingPage(), [
+      batchCostingProvider.overrideWith(
+        () => _FakeBatchCostingNotifier(const <BatchCostingItem>[]),
+      ),
+    ]);
+
+    final l10n = AppLocalizations.of(
+      tester.element(find.byType(BatchCostingPage)),
+    )!;
+
+    await tester.tap(find.text(l10n.batchCostingReviewAddManualItemButton));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(l10n.saveButton));
+    await tester.pump();
+    expect(find.text(l10n.csvNameRequiredError), findsOneWidget);
+
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('batch-costing-item-name')),
+      'Benchy',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('batch-costing-item-quantity')),
+      '0',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('batch-costing-item-weight')),
+      '0',
+    );
+    await tester.tap(find.text(l10n.saveButton));
+    await tester.pump();
+    expect(find.text(l10n.invalidNumber), findsWidgets);
+
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('batch-costing-item-quantity')),
+      '1',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('batch-costing-item-weight')),
+      '1',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('batch-costing-item-duration-hours')),
+      '0',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('batch-costing-item-duration-minutes')),
+      '1',
+    );
+    await tester.tap(find.text(l10n.saveButton));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Benchy'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(l10n.editButton).last);
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('batch-costing-item-name')),
+      '',
+    );
+    await tester.tap(find.text(l10n.saveButton));
+    await tester.pump();
+
+    expect(find.text(l10n.csvNameRequiredError), findsOneWidget);
+    expect(find.text('Benchy'), findsOneWidget);
+  });
 }
 
 class _FakeBatchCostingNotifier extends BatchCostingNotifier {
-  _FakeBatchCostingNotifier(this._item);
+  _FakeBatchCostingNotifier(this._items);
 
-  final BatchCostingItem _item;
+  final List<BatchCostingItem> _items;
 
   @override
   BatchCostingState build() {
-    return BatchCostingState(items: [_item]);
+    return BatchCostingState(items: _items);
   }
 }


### PR DESCRIPTION
## Summary
- Added manual item add/edit/remove from the batch review screen behind batch costing visibility.
- Preserved G-code item metadata on edit and kept continue blocked when the list becomes empty.
- Updated batch costing docs and localized new UI copy across all supported locales.

## ClickUp
- https://app.clickup.com/t/86c9u8dqt

## Tests
- fvm flutter analyze ✅
- fvm flutter test test/batch_costing ✅
- make flutter_test ⚠️ fails in unrelated pre-existing tests outside batch costing

## Risks
- Full-suite failures appear unrelated to this change.

## Follow-ups
- None.

## Final verification
- Batch costing tests pass.
- Analyzer passes.
- Full suite still has unrelated failures.

## Localization
- Updated all supported intl_*.arb files and regenerated localization output.

## Wiki updates
- Updated docs/product/batch_costing.md.

## ClickUp status updates
- Not moved to in review yet; per workflow, do that after PR exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add manual batch items in review; edit existing items with input validation; add/remove items; analytics events logged for add/edit.
* **Localization**
  * Added UI strings for batch costing in EN, DE, ES, FR, ID, IT, JA, NL, PT, TH.
* **Tests**
  * Added widget tests covering add/edit/remove flows and validation scenarios.
* **Documentation**
  * Clarified batch review workflow and manual item management; noted follow-up question about discounts.
* **Chores**
  * App version incremented.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RemeJuan/threed_print_cost_calculator/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->