### PR TITLE
[86c9u8ec7] Batch costing: add material assignment step

### DIFF
--- a/docs/agent-instructions/task-execution-instructions.md
+++ b/docs/agent-instructions/task-execution-instructions.md
@@ -157,7 +157,7 @@ For every implementation task, run at minimum:
 - existing calculator tests where calculation logic is touched
 - existing G-code import tests where import logic is touched
 
-Run `make flutter_test` when shared app behaviour is touched.
+Run `make flutter_test` to ensure all tests are passing.
 
 For tasks that add or change user-facing strings, verify localization files are updated and generated localization output is refreshed using `fvm flutter gen-l10n`.
 
@@ -189,7 +189,6 @@ Stop and report back when:
 
 - required behaviour is unclear
 - a required previous task output is missing
-- existing tests fail for unrelated reasons
 - the implementation requires changing existing public behaviour
 - the task requires broad architectural changes
 - the implementation would introduce a new package
@@ -200,6 +199,7 @@ Stop and report back when:
 
 Before the final response, verify:
 
+- All unit tests are passing, not just those related to file changes
 - Required verification has been rerun after fixes.
 - Existing calculator and G-code flows were checked when touched.
 - New user-facing strings are localized, or no new user-facing strings were added.

--- a/lib/batch_costing/batch_material_assignment_page.dart
+++ b/lib/batch_costing/batch_material_assignment_page.dart
@@ -1,27 +1,407 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import 'package:threed_print_cost_calculator/batch_costing/batch_pricing_scope_page.dart';
+import 'package:threed_print_cost_calculator/batch_costing/providers/batch_costing_notifier.dart';
+import 'package:threed_print_cost_calculator/batch_costing/state/batch_costing_state.dart';
+import 'package:threed_print_cost_calculator/batch_costing/model/batch_costing_item.dart';
+import 'package:threed_print_cost_calculator/database/repositories/materials_repository.dart';
 import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
+import 'package:threed_print_cost_calculator/materials/model/stock_status.dart';
+import 'package:threed_print_cost_calculator/settings/model/material_model.dart';
 import 'package:threed_print_cost_calculator/shared/providers/batch_costing_visibility.dart';
+import 'package:threed_print_cost_calculator/shared/utils/weight_formatting.dart';
 
-class BatchMaterialAssignmentPage extends ConsumerWidget {
+class BatchMaterialAssignmentPage extends ConsumerStatefulWidget {
   const BatchMaterialAssignmentPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<BatchMaterialAssignmentPage> createState() =>
+      _BatchMaterialAssignmentPageState();
+}
+
+class _BatchMaterialAssignmentPageState
+    extends ConsumerState<BatchMaterialAssignmentPage> {
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  Widget build(BuildContext context) {
     if (!ref.watch(batchCostingEnabledProvider)) return const SizedBox.shrink();
 
     final l10n = AppLocalizations.of(context)!;
-    return Scaffold(
-      appBar: AppBar(title: Text(l10n.batchCostingMaterialAssignmentAppBarTitle)),
-      body: SafeArea(
-        child: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Text(l10n.batchCostingMaterialAssignmentSubtitle),
+    final state = ref.watch(batchCostingProvider);
+    final materialsAsync = ref.watch(materialsStreamProvider);
+
+    return materialsAsync.when(
+      data: (materials) {
+        final sortedMaterials = [...materials]
+          ..sort((a, b) {
+            final statusA = calculateStockStatus(a);
+            final statusB = calculateStockStatus(b);
+            final order = _stockSortOrder(
+              statusA,
+            ).compareTo(_stockSortOrder(statusB));
+            if (order != 0) return order;
+            return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+          });
+
+        return Scaffold(
+          appBar: AppBar(
+            title: Text(l10n.batchCostingMaterialAssignmentAppBarTitle),
+            leading: BackButton(onPressed: () => Navigator.of(context).pop()),
+          ),
+          body: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Text(
+                      l10n.batchCostingMaterialAssignmentSubtitle,
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                    const SizedBox(height: 16),
+                    SegmentedButton<BatchMaterialAssignmentMode>(
+                      segments: [
+                        ButtonSegment(
+                          value: BatchMaterialAssignmentMode.batchWide,
+                          label: Text(
+                            l10n.batchCostingMaterialAssignmentBatchWideMode,
+                          ),
+                        ),
+                        ButtonSegment(
+                          value: BatchMaterialAssignmentMode.perItem,
+                          label: Text(
+                            l10n.batchCostingMaterialAssignmentPerItemMode,
+                          ),
+                        ),
+                      ],
+                      selected: {state.materialAssignmentMode},
+                      onSelectionChanged: (selected) {
+                        ref
+                            .read(batchCostingProvider.notifier)
+                            .setMaterialAssignmentMode(selected.first);
+                      },
+                    ),
+                    const SizedBox(height: 16),
+                    Expanded(
+                      child: materials.isEmpty
+                          ? Center(
+                              child: Padding(
+                                padding: const EdgeInsets.all(16),
+                                child: Text(
+                                  l10n.batchCostingMaterialAssignmentNoMaterialsMessage,
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
+                            )
+                          : state.materialAssignmentMode ==
+                                BatchMaterialAssignmentMode.batchWide
+                          ? _BatchWideMaterialSection(
+                              materials: sortedMaterials,
+                              selectedMaterialId: state.batchMaterialId,
+                              warningText: _buildStockWarning(
+                                l10n,
+                                _materialById(
+                                  sortedMaterials,
+                                  state.batchMaterialId,
+                                ),
+                                _totalRequiredWeight(state),
+                              ),
+                              onChanged: (value) {
+                                ref
+                                    .read(batchCostingProvider.notifier)
+                                    .setBatchMaterialId(value);
+                              },
+                              labelText: l10n
+                                  .batchCostingMaterialAssignmentMaterialLabel,
+                              hintText: l10n
+                                  .batchCostingMaterialAssignmentBatchWideHint,
+                              validatorText: l10n
+                                  .batchCostingMaterialAssignmentRequiredError,
+                            )
+                          : ListView.separated(
+                              itemCount: state.items.length,
+                              separatorBuilder: (context, index) =>
+                                  const SizedBox(height: 12),
+                              itemBuilder: (context, index) {
+                                final item = state.items[index];
+                                final selectedMaterial = _materialById(
+                                  sortedMaterials,
+                                  item.materialId,
+                                );
+                                return _PerItemMaterialSection(
+                                  item: item,
+                                  materials: sortedMaterials,
+                                  selectedMaterialId: item.materialId,
+                                  warningText: _buildStockWarning(
+                                    l10n,
+                                    selectedMaterial,
+                                    _itemRequiredWeight(item),
+                                  ),
+                                  onChanged: (value) {
+                                    ref
+                                        .read(batchCostingProvider.notifier)
+                                        .setItemMaterialId(item.id, value);
+                                  },
+                                  labelText: l10n
+                                      .batchCostingMaterialAssignmentMaterialLabel,
+                                  hintText: l10n
+                                      .batchCostingMaterialAssignmentPerItemHint,
+                                  validatorText: l10n
+                                      .batchCostingMaterialAssignmentRequiredError,
+                                );
+                              },
+                            ),
+                    ),
+                    const SizedBox(height: 16),
+                    Row(
+                      children: [
+                        TextButton(
+                          onPressed: () => Navigator.of(context).pop(),
+                          child: Text(
+                            MaterialLocalizations.of(context).backButtonTooltip,
+                          ),
+                        ),
+                        const Spacer(),
+                        FilledButton(
+                          onPressed: materials.isEmpty
+                              ? null
+                              : () => _continue(context),
+                          child: Text(
+                            l10n.batchCostingMaterialAssignmentContinueButton,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+      loading: () => Scaffold(
+        appBar: AppBar(
+          title: Text(l10n.batchCostingMaterialAssignmentAppBarTitle),
+        ),
+        body: const Center(child: CircularProgressIndicator()),
+      ),
+      error: (error, stackTrace) => Scaffold(
+        appBar: AppBar(
+          title: Text(l10n.batchCostingMaterialAssignmentAppBarTitle),
+        ),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(error.toString(), textAlign: TextAlign.center),
+              ),
+              const SizedBox(height: 16),
+              FilledButton(
+                onPressed: () => ref.refresh(materialsStreamProvider),
+                child: Text(l10n.retryButton),
+              ),
+            ],
           ),
         ),
       ),
     );
   }
+
+  void _continue(BuildContext context) {
+    if (!_formKey.currentState!.validate()) return;
+
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(builder: (_) => const BatchPricingScopePage()),
+    );
+  }
+
+  double _totalRequiredWeight(BatchCostingState state) {
+    return state.items.fold<double>(
+      0,
+      (total, item) => total + _itemRequiredWeight(item),
+    );
+  }
+
+  double _itemRequiredWeight(BatchCostingItem item) {
+    return item.printWeightG * item.quantity;
+  }
+
+  MaterialModel? _materialById(List<MaterialModel> materials, String? id) {
+    if (id == null || id.isEmpty) return null;
+    for (final material in materials) {
+      if (material.id == id) return material;
+    }
+    return null;
+  }
+
+  String? _buildStockWarning(
+    AppLocalizations l10n,
+    MaterialModel? material,
+    double requiredWeightG,
+  ) {
+    if (material == null) return null;
+    if (!material.autoDeductEnabled) return null;
+    if (requiredWeightG <= 0) return null;
+    if (material.remainingWeight >= requiredWeightG) return null;
+
+    return l10n.batchCostingMaterialAssignmentStockWarning(
+      formatWeight(requiredWeightG),
+      formatWeight(material.remainingWeight),
+    );
+  }
+
+  int _stockSortOrder(StockStatus status) {
+    return switch (status) {
+      StockStatus.inStock => 0,
+      StockStatus.lowStock => 1,
+      StockStatus.noTracking => 2,
+      StockStatus.outOfStock => 3,
+    };
+  }
+}
+
+class _BatchWideMaterialSection extends StatelessWidget {
+  const _BatchWideMaterialSection({
+    required this.materials,
+    required this.selectedMaterialId,
+    required this.warningText,
+    required this.onChanged,
+    required this.labelText,
+    required this.hintText,
+    required this.validatorText,
+  });
+
+  final List<MaterialModel> materials;
+  final String? selectedMaterialId;
+  final String? warningText;
+  final ValueChanged<String?> onChanged;
+  final String labelText;
+  final String hintText;
+  final String validatorText;
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedValue = materials.any((m) => m.id == selectedMaterialId)
+        ? selectedMaterialId
+        : null;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        DropdownButtonFormField<String>(
+          initialValue: selectedValue,
+          decoration: InputDecoration(
+            labelText: labelText,
+            border: const OutlineInputBorder(),
+          ),
+          hint: Text(hintText),
+          items: materials
+              .map(
+                (material) => DropdownMenuItem<String>(
+                  value: material.id,
+                  child: Text(material.name),
+                ),
+              )
+              .toList(),
+          validator: (value) => value == null ? validatorText : null,
+          onChanged: onChanged,
+        ),
+        if (warningText != null) ...[
+          const SizedBox(height: 8),
+          _warningBox(context, warningText!),
+        ],
+      ],
+    );
+  }
+}
+
+class _PerItemMaterialSection extends StatelessWidget {
+  const _PerItemMaterialSection({
+    required this.item,
+    required this.materials,
+    required this.selectedMaterialId,
+    required this.warningText,
+    required this.onChanged,
+    required this.labelText,
+    required this.hintText,
+    required this.validatorText,
+  });
+
+  final BatchCostingItem item;
+  final List<MaterialModel> materials;
+  final String? selectedMaterialId;
+  final String? warningText;
+  final ValueChanged<String?> onChanged;
+  final String labelText;
+  final String hintText;
+  final String validatorText;
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedValue = materials.any((m) => m.id == selectedMaterialId)
+        ? selectedMaterialId
+        : null;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              item.displayName,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            DropdownButtonFormField<String>(
+              initialValue: selectedValue,
+              decoration: InputDecoration(
+                labelText: labelText,
+                border: const OutlineInputBorder(),
+              ),
+              hint: Text(hintText),
+              items: materials
+                  .map(
+                    (material) => DropdownMenuItem<String>(
+                      value: material.id,
+                      child: Text(material.name),
+                    ),
+                  )
+                  .toList(),
+              validator: (value) => value == null ? validatorText : null,
+              onChanged: onChanged,
+            ),
+            if (warningText != null) ...[
+              const SizedBox(height: 8),
+              _warningBox(context, warningText!),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+Widget _warningBox(BuildContext context, String text) {
+  final colors = Theme.of(context).colorScheme;
+  return Container(
+    width: double.infinity,
+    padding: const EdgeInsets.all(12),
+    decoration: BoxDecoration(
+      color: colors.errorContainer,
+      borderRadius: BorderRadius.circular(12),
+    ),
+    child: Text(
+      text,
+      style: Theme.of(
+        context,
+      ).textTheme.bodySmall?.copyWith(color: colors.onErrorContainer),
+    ),
+  );
 }

--- a/lib/batch_costing/batch_pricing_scope_page.dart
+++ b/lib/batch_costing/batch_pricing_scope_page.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
+import 'package:threed_print_cost_calculator/shared/providers/batch_costing_visibility.dart';
+
+class BatchPricingScopePage extends ConsumerWidget {
+  const BatchPricingScopePage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!ref.watch(batchCostingEnabledProvider)) return const SizedBox.shrink();
+
+    final l10n = AppLocalizations.of(context)!;
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.batchCostingPricingScopeAppBarTitle)),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text(l10n.batchCostingPricingScopeSubtitle),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/batch_costing/providers/batch_costing_notifier.dart
+++ b/lib/batch_costing/providers/batch_costing_notifier.dart
@@ -25,9 +25,7 @@ class BatchCostingNotifier extends Notifier<BatchCostingState> {
   void setBatchPrinterId(String? printerId) {
     final updatedPrinterIds = printerId == null
         ? state.itemPrinterIds
-        : {
-            for (final item in state.items) item.id: printerId,
-          };
+        : {for (final item in state.items) item.id: printerId};
 
     state = state.copyWith(
       batchPrinterId: printerId,
@@ -45,6 +43,46 @@ class BatchCostingNotifier extends Notifier<BatchCostingState> {
     }
 
     state = state.copyWith(itemPrinterIds: updated);
+  }
+
+  void setMaterialAssignmentMode(BatchMaterialAssignmentMode mode) {
+    state = state.copyWith(materialAssignmentMode: mode);
+    if (mode == BatchMaterialAssignmentMode.batchWide &&
+        state.batchMaterialId != null) {
+      final materialId = state.batchMaterialId;
+      state = state.copyWith(
+        items: [
+          for (final item in state.items) item.copyWith(materialId: materialId),
+        ],
+      );
+    }
+  }
+
+  void setBatchMaterialId(String? materialId) {
+    final updatedItems = materialId == null
+        ? [for (final item in state.items) item.copyWith(materialId: null)]
+        : [
+            for (final item in state.items)
+              item.copyWith(materialId: materialId),
+          ];
+
+    state = state.copyWith(
+      items: updatedItems,
+      batchMaterialId: materialId,
+      clearBatchMaterialId: materialId == null,
+    );
+  }
+
+  void setItemMaterialId(String itemId, String? materialId) {
+    state = state.copyWith(
+      items: [
+        for (final current in state.items)
+          if (current.id == itemId)
+            current.copyWith(materialId: materialId)
+          else
+            current,
+      ],
+    );
   }
 
   void addItem(BatchCostingItem item) {

--- a/lib/batch_costing/state/batch_costing_state.dart
+++ b/lib/batch_costing/state/batch_costing_state.dart
@@ -4,19 +4,27 @@ import 'package:threed_print_cost_calculator/batch_costing/model/batch_costing_i
 
 enum BatchPrinterAssignmentMode { batchWide, perItem }
 
+enum BatchMaterialAssignmentMode { batchWide, perItem }
+
 class BatchCostingState with FormzMixin {
   final List<BatchCostingItem> items;
   final BatchPrinterAssignmentMode printerAssignmentMode;
   final String? batchPrinterId;
   final Map<String, String> itemPrinterIds;
+  final BatchMaterialAssignmentMode materialAssignmentMode;
+  final String? batchMaterialId;
 
   BatchCostingState({
     List<BatchCostingItem>? items,
     this.printerAssignmentMode = BatchPrinterAssignmentMode.batchWide,
     this.batchPrinterId,
     Map<String, String>? itemPrinterIds,
+    this.materialAssignmentMode = BatchMaterialAssignmentMode.batchWide,
+    this.batchMaterialId,
   }) : items = List.unmodifiable(items ?? const <BatchCostingItem>[]),
-       itemPrinterIds = Map.unmodifiable(itemPrinterIds ?? const <String, String>{});
+       itemPrinterIds = Map.unmodifiable(
+         itemPrinterIds ?? const <String, String>{},
+       );
 
   BatchCostingState copyWith({
     List<BatchCostingItem>? items,
@@ -25,12 +33,25 @@ class BatchCostingState with FormzMixin {
     bool clearBatchPrinterId = false,
     Map<String, String>? itemPrinterIds,
     bool clearItemPrinterIds = false,
+    BatchMaterialAssignmentMode? materialAssignmentMode,
+    String? batchMaterialId,
+    bool clearBatchMaterialId = false,
   }) {
     return BatchCostingState(
       items: items ?? this.items,
-      printerAssignmentMode: printerAssignmentMode ?? this.printerAssignmentMode,
-      batchPrinterId: clearBatchPrinterId ? null : batchPrinterId ?? this.batchPrinterId,
-      itemPrinterIds: clearItemPrinterIds ? null : itemPrinterIds ?? this.itemPrinterIds,
+      printerAssignmentMode:
+          printerAssignmentMode ?? this.printerAssignmentMode,
+      batchPrinterId: clearBatchPrinterId
+          ? null
+          : batchPrinterId ?? this.batchPrinterId,
+      itemPrinterIds: clearItemPrinterIds
+          ? null
+          : itemPrinterIds ?? this.itemPrinterIds,
+      materialAssignmentMode:
+          materialAssignmentMode ?? this.materialAssignmentMode,
+      batchMaterialId: clearBatchMaterialId
+          ? null
+          : batchMaterialId ?? this.batchMaterialId,
     );
   }
 

--- a/lib/calculator/provider/calculator_notifier.dart
+++ b/lib/calculator/provider/calculator_notifier.dart
@@ -81,27 +81,31 @@ class CalculatorProvider extends Notifier<CalculatorState> {
       shouldSubmit = true;
     }
 
-    if (state.baselineSetupFee != settingsSetupFee) {
-      nextState = nextState.copyWith(baselineSetupFee: settingsSetupFee);
-    }
-    final setupFeeOverridden = state.setupFee.value != state.baselineSetupFee;
-    if (!setupFeeOverridden && state.setupFee.value != settingsSetupFee) {
-      nextState = nextState.copyWith(
-        setupFee: NumberInput.dirty(value: settingsSetupFee),
-      );
-      shouldSubmit = true;
-    }
+    if (!state.markupPercentOverridden) {
+      if (state.baselineSetupFee != settingsSetupFee) {
+        nextState = nextState.copyWith(baselineSetupFee: settingsSetupFee);
+      }
+      final setupFeeOverridden =
+          state.setupFee.value != state.baselineSetupFee;
+      if (!setupFeeOverridden && state.setupFee.value != settingsSetupFee) {
+        nextState = nextState.copyWith(
+          setupFee: NumberInput.dirty(value: settingsSetupFee),
+        );
+        shouldSubmit = true;
+      }
 
-    if (state.baselineRoundingMode != settingsRoundingMode) {
-      nextState = nextState.copyWith(
-        baselineRoundingMode: settingsRoundingMode,
-      );
-    }
-    final roundingModeOverridden =
-        state.roundingMode != state.baselineRoundingMode;
-    if (!roundingModeOverridden && state.roundingMode != settingsRoundingMode) {
-      nextState = nextState.copyWith(roundingMode: settingsRoundingMode);
-      shouldSubmit = true;
+      if (state.baselineRoundingMode != settingsRoundingMode) {
+        nextState = nextState.copyWith(
+          baselineRoundingMode: settingsRoundingMode,
+        );
+      }
+      final roundingModeOverridden =
+          state.roundingMode != state.baselineRoundingMode;
+      if (!roundingModeOverridden &&
+          state.roundingMode != settingsRoundingMode) {
+        nextState = nextState.copyWith(roundingMode: settingsRoundingMode);
+        shouldSubmit = true;
+      }
     }
 
     if (identical(nextState, state)) return;

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2414,8 +2414,77 @@ abstract class AppLocalizations {
   /// No description provided for @batchCostingMaterialAssignmentSubtitle.
   ///
   /// In en, this message translates to:
-  /// **'Material assignment continues in the next batch costing step.'**
+  /// **'Assign materials or spools before pricing.'**
   String get batchCostingMaterialAssignmentSubtitle;
+
+  /// No description provided for @batchCostingMaterialAssignmentMaterialLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Material or spool'**
+  String get batchCostingMaterialAssignmentMaterialLabel;
+
+  /// No description provided for @batchCostingMaterialAssignmentBatchWideMode.
+  ///
+  /// In en, this message translates to:
+  /// **'Batch-wide'**
+  String get batchCostingMaterialAssignmentBatchWideMode;
+
+  /// No description provided for @batchCostingMaterialAssignmentPerItemMode.
+  ///
+  /// In en, this message translates to:
+  /// **'Per item'**
+  String get batchCostingMaterialAssignmentPerItemMode;
+
+  /// No description provided for @batchCostingMaterialAssignmentBatchWideHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose one material for all items.'**
+  String get batchCostingMaterialAssignmentBatchWideHint;
+
+  /// No description provided for @batchCostingMaterialAssignmentPerItemHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose a material for this item.'**
+  String get batchCostingMaterialAssignmentPerItemHint;
+
+  /// No description provided for @batchCostingMaterialAssignmentRequiredError.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose a material to continue.'**
+  String get batchCostingMaterialAssignmentRequiredError;
+
+  /// No description provided for @batchCostingMaterialAssignmentContinueButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Continue'**
+  String get batchCostingMaterialAssignmentContinueButton;
+
+  /// No description provided for @batchCostingMaterialAssignmentNoMaterialsMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Add at least one material or spool to continue.'**
+  String get batchCostingMaterialAssignmentNoMaterialsMessage;
+
+  /// No description provided for @batchCostingMaterialAssignmentStockWarning.
+  ///
+  /// In en, this message translates to:
+  /// **'Required {required} exceeds selected stock {available}.'**
+  String batchCostingMaterialAssignmentStockWarning(
+    Object available,
+    Object required,
+  );
+
+  /// No description provided for @batchCostingPricingScopeAppBarTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Pricing scope'**
+  String get batchCostingPricingScopeAppBarTitle;
+
+  /// No description provided for @batchCostingPricingScopeSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Set where each pricing value applies.'**
+  String get batchCostingPricingScopeSubtitle;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1283,5 +1283,49 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get batchCostingMaterialAssignmentSubtitle =>
-      'Die Materialzuweisung geht im nächsten Schritt weiter.';
+      'Material oder Spule vor dem Preis festlegen.';
+
+  @override
+  String get batchCostingMaterialAssignmentMaterialLabel =>
+      'Material oder Spule';
+
+  @override
+  String get batchCostingMaterialAssignmentBatchWideMode => 'Gesamter Stapel';
+
+  @override
+  String get batchCostingMaterialAssignmentPerItemMode => 'Pro Element';
+
+  @override
+  String get batchCostingMaterialAssignmentBatchWideHint =>
+      'Ein Material für alle Elemente wählen.';
+
+  @override
+  String get batchCostingMaterialAssignmentPerItemHint =>
+      'Wähle ein Material für dieses Element.';
+
+  @override
+  String get batchCostingMaterialAssignmentRequiredError =>
+      'Material zum Fortfahren wählen.';
+
+  @override
+  String get batchCostingMaterialAssignmentContinueButton => 'Weiter';
+
+  @override
+  String get batchCostingMaterialAssignmentNoMaterialsMessage =>
+      'Mindestens ein Material oder eine Spule hinzufügen, um fortzufahren.';
+
+  @override
+  String batchCostingMaterialAssignmentStockWarning(
+    Object available,
+    Object required,
+  ) {
+    return 'Benötigt $required übersteigt den ausgewählten Bestand $available.';
+  }
+
+  @override
+  String get batchCostingPricingScopeAppBarTitle => 'Preisbereich';
+
+  @override
+  String get batchCostingPricingScopeSubtitle =>
+      'Lege fest, wo jeder Preiswert gilt.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1270,5 +1270,48 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get batchCostingMaterialAssignmentSubtitle =>
-      'Material assignment continues in the next batch costing step.';
+      'Assign materials or spools before pricing.';
+
+  @override
+  String get batchCostingMaterialAssignmentMaterialLabel => 'Material or spool';
+
+  @override
+  String get batchCostingMaterialAssignmentBatchWideMode => 'Batch-wide';
+
+  @override
+  String get batchCostingMaterialAssignmentPerItemMode => 'Per item';
+
+  @override
+  String get batchCostingMaterialAssignmentBatchWideHint =>
+      'Choose one material for all items.';
+
+  @override
+  String get batchCostingMaterialAssignmentPerItemHint =>
+      'Choose a material for this item.';
+
+  @override
+  String get batchCostingMaterialAssignmentRequiredError =>
+      'Choose a material to continue.';
+
+  @override
+  String get batchCostingMaterialAssignmentContinueButton => 'Continue';
+
+  @override
+  String get batchCostingMaterialAssignmentNoMaterialsMessage =>
+      'Add at least one material or spool to continue.';
+
+  @override
+  String batchCostingMaterialAssignmentStockWarning(
+    Object available,
+    Object required,
+  ) {
+    return 'Required $required exceeds selected stock $available.';
+  }
+
+  @override
+  String get batchCostingPricingScopeAppBarTitle => 'Pricing scope';
+
+  @override
+  String get batchCostingPricingScopeSubtitle =>
+      'Set where each pricing value applies.';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1287,5 +1287,48 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get batchCostingMaterialAssignmentSubtitle =>
-      'La asignación de material continúa en el siguiente paso.';
+      'Asigna materiales o bobinas antes de fijar el precio.';
+
+  @override
+  String get batchCostingMaterialAssignmentMaterialLabel => 'Material o bobina';
+
+  @override
+  String get batchCostingMaterialAssignmentBatchWideMode => 'Todo el lote';
+
+  @override
+  String get batchCostingMaterialAssignmentPerItemMode => 'Por elemento';
+
+  @override
+  String get batchCostingMaterialAssignmentBatchWideHint =>
+      'Elige un material para todos los elementos.';
+
+  @override
+  String get batchCostingMaterialAssignmentPerItemHint =>
+      'Elige un material para este elemento.';
+
+  @override
+  String get batchCostingMaterialAssignmentRequiredError =>
+      'Elige un material para continuar.';
+
+  @override
+  String get batchCostingMaterialAssignmentContinueButton => 'Continuar';
+
+  @override
+  String get batchCostingMaterialAssignmentNoMaterialsMessage =>
+      'Añade al menos un material o bobina para continuar.';
+
+  @override
+  String batchCostingMaterialAssignmentStockWarning(
+    Object available,
+    Object required,
+  ) {
+    return 'Lo requerido $required supera el stock seleccionado $available.';
+  }
+
+  @override
+  String get batchCostingPricingScopeAppBarTitle => 'Ámbito de precio';
+
+  @override
+  String get batchCostingPricingScopeSubtitle =>
+      'Define dónde se aplica cada valor de precio.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1300,5 +1300,49 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get batchCostingMaterialAssignmentSubtitle =>
-      'L\'attribution du matériau continue à l\'étape suivante.';
+      'Attribuez les matériaux ou bobines avant le prix.';
+
+  @override
+  String get batchCostingMaterialAssignmentMaterialLabel =>
+      'Matériau ou bobine';
+
+  @override
+  String get batchCostingMaterialAssignmentBatchWideMode => 'Lot entier';
+
+  @override
+  String get batchCostingMaterialAssignmentPerItemMode => 'Par élément';
+
+  @override
+  String get batchCostingMaterialAssignmentBatchWideHint =>
+      'Choisissez un matériau pour tous les éléments.';
+
+  @override
+  String get batchCostingMaterialAssignmentPerItemHint =>
+      'Choisissez un matériau pour cet élément.';
+
+  @override
+  String get batchCostingMaterialAssignmentRequiredError =>
+      'Choisissez un matériau pour continuer.';
+
+  @override
+  String get batchCostingMaterialAssignmentContinueButton => 'Continuer';
+
+  @override
+  String get batchCostingMaterialAssignmentNoMaterialsMessage =>
+      'Ajoutez au moins un matériau ou une bobine pour continuer.';
+
+  @override
+  String batchCostingMaterialAssignmentStockWarning(
+    Object available,
+    Object required,
+  ) {
+    return 'Le requis $required dépasse le stock sélectionné $available.';
+  }
+
+  @override
+  String get batchCostingPricingScopeAppBarTitle => 'Portée du prix';
+
+  @override
+  String get batchCostingPricingScopeSubtitle =>
+      'Définissez où chaque valeur de prix s\'applique.';
 }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -1269,5 +1269,49 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get batchCostingMaterialAssignmentSubtitle =>
-      'Penugasan material berlanjut pada langkah berikutnya.';
+      'Tetapkan material atau spool sebelum harga.';
+
+  @override
+  String get batchCostingMaterialAssignmentMaterialLabel =>
+      'Material atau spool';
+
+  @override
+  String get batchCostingMaterialAssignmentBatchWideMode => 'Seluruh batch';
+
+  @override
+  String get batchCostingMaterialAssignmentPerItemMode => 'Per item';
+
+  @override
+  String get batchCostingMaterialAssignmentBatchWideHint =>
+      'Pilih satu material untuk semua item.';
+
+  @override
+  String get batchCostingMaterialAssignmentPerItemHint =>
+      'Pilih material untuk item ini.';
+
+  @override
+  String get batchCostingMaterialAssignmentRequiredError =>
+      'Pilih material untuk melanjutkan.';
+
+  @override
+  String get batchCostingMaterialAssignmentContinueButton => 'Lanjutkan';
+
+  @override
+  String get batchCostingMaterialAssignmentNoMaterialsMessage =>
+      'Tambahkan setidaknya satu material atau spool untuk melanjutkan.';
+
+  @override
+  String batchCostingMaterialAssignmentStockWarning(
+    Object available,
+    Object required,
+  ) {
+    return 'Yang dibutuhkan $required melebihi stok terpilih $available.';
+  }
+
+  @override
+  String get batchCostingPricingScopeAppBarTitle => 'Ruang harga';
+
+  @override
+  String get batchCostingPricingScopeSubtitle =>
+      'Atur di mana setiap nilai harga berlaku.';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1292,5 +1292,49 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get batchCostingMaterialAssignmentSubtitle =>
-      'L\'assegnazione del materiale continua nel passaggio successivo.';
+      'Assegna materiali o bobine prima del prezzo.';
+
+  @override
+  String get batchCostingMaterialAssignmentMaterialLabel =>
+      'Materiale o bobina';
+
+  @override
+  String get batchCostingMaterialAssignmentBatchWideMode => 'Intero batch';
+
+  @override
+  String get batchCostingMaterialAssignmentPerItemMode => 'Per elemento';
+
+  @override
+  String get batchCostingMaterialAssignmentBatchWideHint =>
+      'Scegli un materiale per tutti gli elementi.';
+
+  @override
+  String get batchCostingMaterialAssignmentPerItemHint =>
+      'Scegli un materiale per questo elemento.';
+
+  @override
+  String get batchCostingMaterialAssignmentRequiredError =>
+      'Scegli un materiale per continuare.';
+
+  @override
+  String get batchCostingMaterialAssignmentContinueButton => 'Continua';
+
+  @override
+  String get batchCostingMaterialAssignmentNoMaterialsMessage =>
+      'Aggiungi almeno un materiale o una bobina per continuare.';
+
+  @override
+  String batchCostingMaterialAssignmentStockWarning(
+    Object available,
+    Object required,
+  ) {
+    return 'Il richiesto $required supera lo stock selezionato $available.';
+  }
+
+  @override
+  String get batchCostingPricingScopeAppBarTitle => 'Ambito prezzo';
+
+  @override
+  String get batchCostingPricingScopeSubtitle =>
+      'Imposta dove si applica ogni valore di prezzo.';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1238,5 +1238,45 @@ class AppLocalizationsJa extends AppLocalizations {
   String get batchCostingMaterialAssignmentAppBarTitle => '材料割り当て';
 
   @override
-  String get batchCostingMaterialAssignmentSubtitle => '材料の割り当ては次のステップで続きます。';
+  String get batchCostingMaterialAssignmentSubtitle => '価格設定の前に材料やスプールを割り当てます。';
+
+  @override
+  String get batchCostingMaterialAssignmentMaterialLabel => '材料またはスプール';
+
+  @override
+  String get batchCostingMaterialAssignmentBatchWideMode => 'バッチ全体';
+
+  @override
+  String get batchCostingMaterialAssignmentPerItemMode => 'アイテムごと';
+
+  @override
+  String get batchCostingMaterialAssignmentBatchWideHint =>
+      'すべてのアイテムに1つの材料を選びます。';
+
+  @override
+  String get batchCostingMaterialAssignmentPerItemHint => 'このアイテムの材料を選びます。';
+
+  @override
+  String get batchCostingMaterialAssignmentRequiredError => '続けるには材料を選んでください。';
+
+  @override
+  String get batchCostingMaterialAssignmentContinueButton => '続ける';
+
+  @override
+  String get batchCostingMaterialAssignmentNoMaterialsMessage =>
+      '続けるには、少なくとも1つの材料またはスプールを追加してください。';
+
+  @override
+  String batchCostingMaterialAssignmentStockWarning(
+    Object available,
+    Object required,
+  ) {
+    return '必要量 $required が選択中の在庫 $available を超えています。';
+  }
+
+  @override
+  String get batchCostingPricingScopeAppBarTitle => '価格範囲';
+
+  @override
+  String get batchCostingPricingScopeSubtitle => '各価格値の適用先を設定します。';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1283,5 +1283,49 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get batchCostingMaterialAssignmentSubtitle =>
-      'De materiaaltoewijzing gaat verder in de volgende stap.';
+      'Wijs materialen of spoelen toe vóór de prijs.';
+
+  @override
+  String get batchCostingMaterialAssignmentMaterialLabel =>
+      'Materiaal of spoel';
+
+  @override
+  String get batchCostingMaterialAssignmentBatchWideMode => 'Hele batch';
+
+  @override
+  String get batchCostingMaterialAssignmentPerItemMode => 'Per item';
+
+  @override
+  String get batchCostingMaterialAssignmentBatchWideHint =>
+      'Kies één materiaal voor alle items.';
+
+  @override
+  String get batchCostingMaterialAssignmentPerItemHint =>
+      'Kies een materiaal voor dit item.';
+
+  @override
+  String get batchCostingMaterialAssignmentRequiredError =>
+      'Kies een materiaal om door te gaan.';
+
+  @override
+  String get batchCostingMaterialAssignmentContinueButton => 'Doorgaan';
+
+  @override
+  String get batchCostingMaterialAssignmentNoMaterialsMessage =>
+      'Voeg minstens één materiaal of spoel toe om door te gaan.';
+
+  @override
+  String batchCostingMaterialAssignmentStockWarning(
+    Object available,
+    Object required,
+  ) {
+    return 'Benodigd $required overschrijdt de geselecteerde voorraad $available.';
+  }
+
+  @override
+  String get batchCostingPricingScopeAppBarTitle => 'Prijsbereik';
+
+  @override
+  String get batchCostingPricingScopeSubtitle =>
+      'Stel in waar elke prijswaarde geldt.';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1285,5 +1285,49 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get batchCostingMaterialAssignmentSubtitle =>
-      'A atribuição de material continua na próxima etapa.';
+      'Atribua materiais ou bobinas antes do preço.';
+
+  @override
+  String get batchCostingMaterialAssignmentMaterialLabel =>
+      'Material ou bobina';
+
+  @override
+  String get batchCostingMaterialAssignmentBatchWideMode => 'Lote inteiro';
+
+  @override
+  String get batchCostingMaterialAssignmentPerItemMode => 'Por item';
+
+  @override
+  String get batchCostingMaterialAssignmentBatchWideHint =>
+      'Escolha um material para todos os itens.';
+
+  @override
+  String get batchCostingMaterialAssignmentPerItemHint =>
+      'Escolha um material para este item.';
+
+  @override
+  String get batchCostingMaterialAssignmentRequiredError =>
+      'Escolha um material para continuar.';
+
+  @override
+  String get batchCostingMaterialAssignmentContinueButton => 'Continuar';
+
+  @override
+  String get batchCostingMaterialAssignmentNoMaterialsMessage =>
+      'Adicione pelo menos um material ou bobina para continuar.';
+
+  @override
+  String batchCostingMaterialAssignmentStockWarning(
+    Object available,
+    Object required,
+  ) {
+    return 'O necessário $required excede o stock selecionado $available.';
+  }
+
+  @override
+  String get batchCostingPricingScopeAppBarTitle => 'Âmbito de preço';
+
+  @override
+  String get batchCostingPricingScopeSubtitle =>
+      'Defina onde cada valor de preço se aplica.';
 }

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -1259,5 +1259,48 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get batchCostingMaterialAssignmentSubtitle =>
-      'การกำหนดวัสดุจะดำเนินต่อในขั้นตอนถัดไป';
+      'กำหนดวัสดุหรือสปูลก่อนตั้งราคา';
+
+  @override
+  String get batchCostingMaterialAssignmentMaterialLabel => 'วัสดุหรือสปูล';
+
+  @override
+  String get batchCostingMaterialAssignmentBatchWideMode => 'ทั้งแบตช์';
+
+  @override
+  String get batchCostingMaterialAssignmentPerItemMode => 'ต่อรายการ';
+
+  @override
+  String get batchCostingMaterialAssignmentBatchWideHint =>
+      'เลือกวัสดุหนึ่งรายการสำหรับทุกรายการ';
+
+  @override
+  String get batchCostingMaterialAssignmentPerItemHint =>
+      'เลือกวัสดุสำหรับรายการนี้';
+
+  @override
+  String get batchCostingMaterialAssignmentRequiredError =>
+      'เลือกวัสดุเพื่อไปต่อ';
+
+  @override
+  String get batchCostingMaterialAssignmentContinueButton => 'ดำเนินการต่อ';
+
+  @override
+  String get batchCostingMaterialAssignmentNoMaterialsMessage =>
+      'เพิ่มวัสดุหรือสปูลอย่างน้อยหนึ่งรายการเพื่อไปต่อ';
+
+  @override
+  String batchCostingMaterialAssignmentStockWarning(
+    Object available,
+    Object required,
+  ) {
+    return 'ต้องใช้ $required เกินสต็อกที่เลือก $available';
+  }
+
+  @override
+  String get batchCostingPricingScopeAppBarTitle => 'ขอบเขตราคา';
+
+  @override
+  String get batchCostingPricingScopeSubtitle =>
+      'กำหนดว่าค่าแต่ละรายการใช้กับส่วนใด';
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -609,5 +609,16 @@
   "batchCostingPrinterAssignmentContinueButton": "Weiter",
   "batchCostingPrinterAssignmentNoPrintersMessage": "Noch sind keine Drucker verfügbar.",
   "batchCostingMaterialAssignmentAppBarTitle": "Materialzuweisung",
-  "batchCostingMaterialAssignmentSubtitle": "Die Materialzuweisung geht im nächsten Schritt weiter."
+  "batchCostingMaterialAssignmentSubtitle": "Material oder Spule vor dem Preis festlegen.",
+  "batchCostingMaterialAssignmentMaterialLabel": "Material oder Spule",
+  "batchCostingMaterialAssignmentBatchWideMode": "Gesamter Stapel",
+  "batchCostingMaterialAssignmentPerItemMode": "Pro Element",
+  "batchCostingMaterialAssignmentBatchWideHint": "Ein Material für alle Elemente wählen.",
+  "batchCostingMaterialAssignmentPerItemHint": "Wähle ein Material für dieses Element.",
+  "batchCostingMaterialAssignmentRequiredError": "Material zum Fortfahren wählen.",
+  "batchCostingMaterialAssignmentContinueButton": "Weiter",
+  "batchCostingMaterialAssignmentNoMaterialsMessage": "Mindestens ein Material oder eine Spule hinzufügen, um fortzufahren.",
+  "batchCostingMaterialAssignmentStockWarning": "Benötigt {required} übersteigt den ausgewählten Bestand {available}.",
+  "batchCostingPricingScopeAppBarTitle": "Preisbereich",
+  "batchCostingPricingScopeSubtitle": "Lege fest, wo jeder Preiswert gilt."
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -537,5 +537,16 @@
   "batchCostingPrinterAssignmentContinueButton": "Continue",
   "batchCostingPrinterAssignmentNoPrintersMessage": "No printers are available yet.",
   "batchCostingMaterialAssignmentAppBarTitle": "Material assignment",
-  "batchCostingMaterialAssignmentSubtitle": "Material assignment continues in the next batch costing step."
+  "batchCostingMaterialAssignmentSubtitle": "Assign materials or spools before pricing.",
+  "batchCostingMaterialAssignmentMaterialLabel": "Material or spool",
+  "batchCostingMaterialAssignmentBatchWideMode": "Batch-wide",
+  "batchCostingMaterialAssignmentPerItemMode": "Per item",
+  "batchCostingMaterialAssignmentBatchWideHint": "Choose one material for all items.",
+  "batchCostingMaterialAssignmentPerItemHint": "Choose a material for this item.",
+  "batchCostingMaterialAssignmentRequiredError": "Choose a material to continue.",
+  "batchCostingMaterialAssignmentContinueButton": "Continue",
+  "batchCostingMaterialAssignmentNoMaterialsMessage": "Add at least one material or spool to continue.",
+  "batchCostingMaterialAssignmentStockWarning": "Required {required} exceeds selected stock {available}.",
+  "batchCostingPricingScopeAppBarTitle": "Pricing scope",
+  "batchCostingPricingScopeSubtitle": "Set where each pricing value applies."
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -608,5 +608,16 @@
   "batchCostingPrinterAssignmentContinueButton": "Continuar",
   "batchCostingPrinterAssignmentNoPrintersMessage": "Aún no hay impresoras disponibles.",
   "batchCostingMaterialAssignmentAppBarTitle": "Asignación de material",
-  "batchCostingMaterialAssignmentSubtitle": "La asignación de material continúa en el siguiente paso."
+  "batchCostingMaterialAssignmentSubtitle": "Asigna materiales o bobinas antes de fijar el precio.",
+  "batchCostingMaterialAssignmentMaterialLabel": "Material o bobina",
+  "batchCostingMaterialAssignmentBatchWideMode": "Todo el lote",
+  "batchCostingMaterialAssignmentPerItemMode": "Por elemento",
+  "batchCostingMaterialAssignmentBatchWideHint": "Elige un material para todos los elementos.",
+  "batchCostingMaterialAssignmentPerItemHint": "Elige un material para este elemento.",
+  "batchCostingMaterialAssignmentRequiredError": "Elige un material para continuar.",
+  "batchCostingMaterialAssignmentContinueButton": "Continuar",
+  "batchCostingMaterialAssignmentNoMaterialsMessage": "Añade al menos un material o bobina para continuar.",
+  "batchCostingMaterialAssignmentStockWarning": "Lo requerido {required} supera el stock seleccionado {available}.",
+  "batchCostingPricingScopeAppBarTitle": "Ámbito de precio",
+  "batchCostingPricingScopeSubtitle": "Define dónde se aplica cada valor de precio."
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -611,5 +611,16 @@
   "batchCostingPrinterAssignmentContinueButton": "Continuer",
   "batchCostingPrinterAssignmentNoPrintersMessage": "Aucune imprimante n'est encore disponible.",
   "batchCostingMaterialAssignmentAppBarTitle": "Attribution du matériau",
-  "batchCostingMaterialAssignmentSubtitle": "L'attribution du matériau continue à l'étape suivante."
+  "batchCostingMaterialAssignmentSubtitle": "Attribuez les matériaux ou bobines avant le prix.",
+  "batchCostingMaterialAssignmentMaterialLabel": "Matériau ou bobine",
+  "batchCostingMaterialAssignmentBatchWideMode": "Lot entier",
+  "batchCostingMaterialAssignmentPerItemMode": "Par élément",
+  "batchCostingMaterialAssignmentBatchWideHint": "Choisissez un matériau pour tous les éléments.",
+  "batchCostingMaterialAssignmentPerItemHint": "Choisissez un matériau pour cet élément.",
+  "batchCostingMaterialAssignmentRequiredError": "Choisissez un matériau pour continuer.",
+  "batchCostingMaterialAssignmentContinueButton": "Continuer",
+  "batchCostingMaterialAssignmentNoMaterialsMessage": "Ajoutez au moins un matériau ou une bobine pour continuer.",
+  "batchCostingMaterialAssignmentStockWarning": "Le requis {required} dépasse le stock sélectionné {available}.",
+  "batchCostingPricingScopeAppBarTitle": "Portée du prix",
+  "batchCostingPricingScopeSubtitle": "Définissez où chaque valeur de prix s'applique."
 }

--- a/lib/l10n/intl_id.arb
+++ b/lib/l10n/intl_id.arb
@@ -609,5 +609,16 @@
   "batchCostingPrinterAssignmentContinueButton": "Lanjutkan",
   "batchCostingPrinterAssignmentNoPrintersMessage": "Belum ada printer yang tersedia.",
   "batchCostingMaterialAssignmentAppBarTitle": "Penugasan material",
-  "batchCostingMaterialAssignmentSubtitle": "Penugasan material berlanjut pada langkah berikutnya."
+  "batchCostingMaterialAssignmentSubtitle": "Tetapkan material atau spool sebelum harga.",
+  "batchCostingMaterialAssignmentMaterialLabel": "Material atau spool",
+  "batchCostingMaterialAssignmentBatchWideMode": "Seluruh batch",
+  "batchCostingMaterialAssignmentPerItemMode": "Per item",
+  "batchCostingMaterialAssignmentBatchWideHint": "Pilih satu material untuk semua item.",
+  "batchCostingMaterialAssignmentPerItemHint": "Pilih material untuk item ini.",
+  "batchCostingMaterialAssignmentRequiredError": "Pilih material untuk melanjutkan.",
+  "batchCostingMaterialAssignmentContinueButton": "Lanjutkan",
+  "batchCostingMaterialAssignmentNoMaterialsMessage": "Tambahkan setidaknya satu material atau spool untuk melanjutkan.",
+  "batchCostingMaterialAssignmentStockWarning": "Yang dibutuhkan {required} melebihi stok terpilih {available}.",
+  "batchCostingPricingScopeAppBarTitle": "Ruang harga",
+  "batchCostingPricingScopeSubtitle": "Atur di mana setiap nilai harga berlaku."
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -609,5 +609,16 @@
   "batchCostingPrinterAssignmentContinueButton": "Continua",
   "batchCostingPrinterAssignmentNoPrintersMessage": "Non ci sono ancora stampanti disponibili.",
   "batchCostingMaterialAssignmentAppBarTitle": "Assegnazione materiale",
-  "batchCostingMaterialAssignmentSubtitle": "L'assegnazione del materiale continua nel passaggio successivo."
+  "batchCostingMaterialAssignmentSubtitle": "Assegna materiali o bobine prima del prezzo.",
+  "batchCostingMaterialAssignmentMaterialLabel": "Materiale o bobina",
+  "batchCostingMaterialAssignmentBatchWideMode": "Intero batch",
+  "batchCostingMaterialAssignmentPerItemMode": "Per elemento",
+  "batchCostingMaterialAssignmentBatchWideHint": "Scegli un materiale per tutti gli elementi.",
+  "batchCostingMaterialAssignmentPerItemHint": "Scegli un materiale per questo elemento.",
+  "batchCostingMaterialAssignmentRequiredError": "Scegli un materiale per continuare.",
+  "batchCostingMaterialAssignmentContinueButton": "Continua",
+  "batchCostingMaterialAssignmentNoMaterialsMessage": "Aggiungi almeno un materiale o una bobina per continuare.",
+  "batchCostingMaterialAssignmentStockWarning": "Il richiesto {required} supera lo stock selezionato {available}.",
+  "batchCostingPricingScopeAppBarTitle": "Ambito prezzo",
+  "batchCostingPricingScopeSubtitle": "Imposta dove si applica ogni valore di prezzo."
 }

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -610,5 +610,16 @@
   "batchCostingPrinterAssignmentContinueButton": "続行",
   "batchCostingPrinterAssignmentNoPrintersMessage": "まだ利用できるプリンターがありません。",
   "batchCostingMaterialAssignmentAppBarTitle": "材料割り当て",
-  "batchCostingMaterialAssignmentSubtitle": "材料の割り当ては次のステップで続きます。"
+  "batchCostingMaterialAssignmentSubtitle": "価格設定の前に材料やスプールを割り当てます。",
+  "batchCostingMaterialAssignmentMaterialLabel": "材料またはスプール",
+  "batchCostingMaterialAssignmentBatchWideMode": "バッチ全体",
+  "batchCostingMaterialAssignmentPerItemMode": "アイテムごと",
+  "batchCostingMaterialAssignmentBatchWideHint": "すべてのアイテムに1つの材料を選びます。",
+  "batchCostingMaterialAssignmentPerItemHint": "このアイテムの材料を選びます。",
+  "batchCostingMaterialAssignmentRequiredError": "続けるには材料を選んでください。",
+  "batchCostingMaterialAssignmentContinueButton": "続ける",
+  "batchCostingMaterialAssignmentNoMaterialsMessage": "続けるには、少なくとも1つの材料またはスプールを追加してください。",
+  "batchCostingMaterialAssignmentStockWarning": "必要量 {required} が選択中の在庫 {available} を超えています。",
+  "batchCostingPricingScopeAppBarTitle": "価格範囲",
+  "batchCostingPricingScopeSubtitle": "各価格値の適用先を設定します。"
 }

--- a/lib/l10n/intl_nl.arb
+++ b/lib/l10n/intl_nl.arb
@@ -610,5 +610,16 @@
   "batchCostingPrinterAssignmentContinueButton": "Doorgaan",
   "batchCostingPrinterAssignmentNoPrintersMessage": "Er zijn nog geen printers beschikbaar.",
   "batchCostingMaterialAssignmentAppBarTitle": "Materiaaltoewijzing",
-  "batchCostingMaterialAssignmentSubtitle": "De materiaaltoewijzing gaat verder in de volgende stap."
+  "batchCostingMaterialAssignmentSubtitle": "Wijs materialen of spoelen toe vóór de prijs.",
+  "batchCostingMaterialAssignmentMaterialLabel": "Materiaal of spoel",
+  "batchCostingMaterialAssignmentBatchWideMode": "Hele batch",
+  "batchCostingMaterialAssignmentPerItemMode": "Per item",
+  "batchCostingMaterialAssignmentBatchWideHint": "Kies één materiaal voor alle items.",
+  "batchCostingMaterialAssignmentPerItemHint": "Kies een materiaal voor dit item.",
+  "batchCostingMaterialAssignmentRequiredError": "Kies een materiaal om door te gaan.",
+  "batchCostingMaterialAssignmentContinueButton": "Doorgaan",
+  "batchCostingMaterialAssignmentNoMaterialsMessage": "Voeg minstens één materiaal of spoel toe om door te gaan.",
+  "batchCostingMaterialAssignmentStockWarning": "Benodigd {required} overschrijdt de geselecteerde voorraad {available}.",
+  "batchCostingPricingScopeAppBarTitle": "Prijsbereik",
+  "batchCostingPricingScopeSubtitle": "Stel in waar elke prijswaarde geldt."
 }

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -610,5 +610,16 @@
   "batchCostingPrinterAssignmentContinueButton": "Continuar",
   "batchCostingPrinterAssignmentNoPrintersMessage": "Ainda não há impressoras disponíveis.",
   "batchCostingMaterialAssignmentAppBarTitle": "Atribuição de material",
-  "batchCostingMaterialAssignmentSubtitle": "A atribuição de material continua na próxima etapa."
+  "batchCostingMaterialAssignmentSubtitle": "Atribua materiais ou bobinas antes do preço.",
+  "batchCostingMaterialAssignmentMaterialLabel": "Material ou bobina",
+  "batchCostingMaterialAssignmentBatchWideMode": "Lote inteiro",
+  "batchCostingMaterialAssignmentPerItemMode": "Por item",
+  "batchCostingMaterialAssignmentBatchWideHint": "Escolha um material para todos os itens.",
+  "batchCostingMaterialAssignmentPerItemHint": "Escolha um material para este item.",
+  "batchCostingMaterialAssignmentRequiredError": "Escolha um material para continuar.",
+  "batchCostingMaterialAssignmentContinueButton": "Continuar",
+  "batchCostingMaterialAssignmentNoMaterialsMessage": "Adicione pelo menos um material ou bobina para continuar.",
+  "batchCostingMaterialAssignmentStockWarning": "O necessário {required} excede o stock selecionado {available}.",
+  "batchCostingPricingScopeAppBarTitle": "Âmbito de preço",
+  "batchCostingPricingScopeSubtitle": "Defina onde cada valor de preço se aplica."
 }

--- a/lib/l10n/intl_th.arb
+++ b/lib/l10n/intl_th.arb
@@ -610,5 +610,16 @@
   "batchCostingPrinterAssignmentContinueButton": "ดำเนินการต่อ",
   "batchCostingPrinterAssignmentNoPrintersMessage": "ยังไม่มีเครื่องพิมพ์ที่พร้อมใช้งาน",
   "batchCostingMaterialAssignmentAppBarTitle": "กำหนดวัสดุ",
-  "batchCostingMaterialAssignmentSubtitle": "การกำหนดวัสดุจะดำเนินต่อในขั้นตอนถัดไป"
+  "batchCostingMaterialAssignmentSubtitle": "กำหนดวัสดุหรือสปูลก่อนตั้งราคา",
+  "batchCostingMaterialAssignmentMaterialLabel": "วัสดุหรือสปูล",
+  "batchCostingMaterialAssignmentBatchWideMode": "ทั้งแบตช์",
+  "batchCostingMaterialAssignmentPerItemMode": "ต่อรายการ",
+  "batchCostingMaterialAssignmentBatchWideHint": "เลือกวัสดุหนึ่งรายการสำหรับทุกรายการ",
+  "batchCostingMaterialAssignmentPerItemHint": "เลือกวัสดุสำหรับรายการนี้",
+  "batchCostingMaterialAssignmentRequiredError": "เลือกวัสดุเพื่อไปต่อ",
+  "batchCostingMaterialAssignmentContinueButton": "ดำเนินการต่อ",
+  "batchCostingMaterialAssignmentNoMaterialsMessage": "เพิ่มวัสดุหรือสปูลอย่างน้อยหนึ่งรายการเพื่อไปต่อ",
+  "batchCostingMaterialAssignmentStockWarning": "ต้องใช้ {required} เกินสต็อกที่เลือก {available}",
+  "batchCostingPricingScopeAppBarTitle": "ขอบเขตราคา",
+  "batchCostingPricingScopeSubtitle": "กำหนดว่าค่าแต่ละรายการใช้กับส่วนใด"
 }

--- a/test/batch_costing/batch_material_assignment_page_test.dart
+++ b/test/batch_costing/batch_material_assignment_page_test.dart
@@ -1,0 +1,226 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:threed_print_cost_calculator/batch_costing/batch_material_assignment_page.dart';
+import 'package:threed_print_cost_calculator/batch_costing/batch_pricing_scope_page.dart';
+import 'package:threed_print_cost_calculator/batch_costing/model/batch_costing_item.dart';
+import 'package:threed_print_cost_calculator/batch_costing/providers/batch_costing_notifier.dart';
+import 'package:threed_print_cost_calculator/batch_costing/state/batch_costing_state.dart';
+import 'package:threed_print_cost_calculator/database/repositories/materials_repository.dart';
+import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
+import 'package:threed_print_cost_calculator/settings/model/material_model.dart';
+import 'package:threed_print_cost_calculator/shared/providers/batch_costing_visibility.dart';
+import 'package:threed_print_cost_calculator/shared/utils/weight_formatting.dart';
+
+import '../helpers/helpers.dart';
+
+void main() {
+  setUpAll(setupTest);
+
+  final items = [
+    BatchCostingItem.manual(
+      id: 'item-1',
+      displayName: 'Benchy',
+      quantity: 2,
+      printWeightG: 20,
+      printDuration: const Duration(minutes: 30),
+    ),
+    BatchCostingItem.manual(
+      id: 'item-2',
+      displayName: 'Cube',
+      quantity: 1,
+      printWeightG: 30,
+      printDuration: const Duration(minutes: 20),
+    ),
+  ];
+
+  final materials = [
+    material('m1', 'PLA Red', remainingWeight: 200, autoDeductEnabled: false),
+    material('m2', 'PLA Blue', remainingWeight: 25, autoDeductEnabled: true),
+  ];
+
+  testWidgets('defaults to batch-wide mode', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      batchCostingEnabledPreferenceKey: true,
+    });
+    final notifier = _FakeBatchCostingNotifier(items);
+
+    await tester.pumpApp(const BatchMaterialAssignmentPage(), [
+      batchCostingProvider.overrideWith(() => notifier),
+      materialsStreamProvider.overrideWith((ref) => Stream.value(materials)),
+    ]);
+
+    await tester.pumpAndSettle();
+
+    expect(
+      notifier.state.materialAssignmentMode,
+      BatchMaterialAssignmentMode.batchWide,
+    );
+  });
+
+  testWidgets('batch-wide selection updates state', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      batchCostingEnabledPreferenceKey: true,
+    });
+    final notifier = _FakeBatchCostingNotifier(items);
+
+    await tester.pumpApp(const BatchMaterialAssignmentPage(), [
+      batchCostingProvider.overrideWith(() => notifier),
+      materialsStreamProvider.overrideWith((ref) => Stream.value(materials)),
+    ]);
+
+    await tester.pumpAndSettle();
+
+    tester
+        .widget<DropdownButtonFormField<String>>(
+          find.byType(DropdownButtonFormField<String>),
+        )
+        .onChanged
+        ?.call('m1');
+    await tester.pumpAndSettle();
+
+    expect(notifier.state.batchMaterialId, 'm1');
+    expect(
+      notifier.state.items.every((item) => item.materialId == 'm1'),
+      isTrue,
+    );
+  });
+
+  testWidgets('per-item mode shows one selector per batch item', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({
+      batchCostingEnabledPreferenceKey: true,
+    });
+    final notifier = _FakeBatchCostingNotifier(items);
+
+    await tester.pumpApp(const BatchMaterialAssignmentPage(), [
+      batchCostingProvider.overrideWith(() => notifier),
+      materialsStreamProvider.overrideWith((ref) => Stream.value(materials)),
+    ]);
+
+    await tester.pumpAndSettle();
+
+    tester
+        .widget<SegmentedButton<BatchMaterialAssignmentMode>>(
+          find.byType(SegmentedButton<BatchMaterialAssignmentMode>),
+        )
+        .onSelectionChanged
+        ?.call({BatchMaterialAssignmentMode.perItem});
+    await tester.pumpAndSettle();
+
+    expect(find.text('Benchy'), findsOneWidget);
+    expect(find.text('Cube'), findsOneWidget);
+    expect(find.byType(DropdownButtonFormField<String>), findsNWidgets(2));
+  });
+
+  testWidgets('missing per-item selection blocks continue', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      batchCostingEnabledPreferenceKey: true,
+    });
+    final notifier = _FakeBatchCostingNotifier(items);
+
+    await tester.pumpApp(const BatchMaterialAssignmentPage(), [
+      batchCostingProvider.overrideWith(() => notifier),
+      materialsStreamProvider.overrideWith((ref) => Stream.value(materials)),
+    ]);
+
+    await tester.pumpAndSettle();
+
+    tester
+        .widget<SegmentedButton<BatchMaterialAssignmentMode>>(
+          find.byType(SegmentedButton<BatchMaterialAssignmentMode>),
+        )
+        .onSelectionChanged
+        ?.call({BatchMaterialAssignmentMode.perItem});
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(FilledButton));
+    await tester.pump();
+
+    final l10n = AppLocalizations.of(
+      tester.element(find.byType(BatchMaterialAssignmentPage)),
+    )!;
+    expect(
+      find.text(l10n.batchCostingMaterialAssignmentRequiredError),
+      findsWidgets,
+    );
+  });
+
+  testWidgets('stock warning appears and continue still works', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      batchCostingEnabledPreferenceKey: true,
+    });
+    final notifier = _FakeBatchCostingNotifier(items);
+
+    await tester.pumpApp(const BatchMaterialAssignmentPage(), [
+      batchCostingProvider.overrideWith(() => notifier),
+      materialsStreamProvider.overrideWith((ref) => Stream.value(materials)),
+    ]);
+
+    await tester.pumpAndSettle();
+
+    tester
+        .widget<DropdownButtonFormField<String>>(
+          find.byType(DropdownButtonFormField<String>),
+        )
+        .onChanged
+        ?.call('m2');
+    await tester.pumpAndSettle();
+
+    final l10n = AppLocalizations.of(
+      tester.element(find.byType(BatchMaterialAssignmentPage)),
+    )!;
+    expect(
+      find.text(
+        l10n.batchCostingMaterialAssignmentStockWarning(
+          formatWeight(70),
+          formatWeight(25),
+        ),
+      ),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byType(FilledButton));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BatchPricingScopePage), findsOneWidget);
+  });
+
+  testWidgets('disabled feature prevents access', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+
+    await tester.pumpApp(const BatchMaterialAssignmentPage());
+
+    expect(find.text('Material assignment'), findsNothing);
+  });
+}
+
+MaterialModel material(
+  String id,
+  String name, {
+  required double remainingWeight,
+  required bool autoDeductEnabled,
+}) {
+  return MaterialModel(
+    id: id,
+    name: name,
+    cost: '20',
+    color: 'Natural',
+    weight: '500',
+    archived: false,
+    autoDeductEnabled: autoDeductEnabled,
+    originalWeight: 500,
+    remainingWeight: remainingWeight,
+  );
+}
+
+class _FakeBatchCostingNotifier extends BatchCostingNotifier {
+  _FakeBatchCostingNotifier(this._items);
+
+  final List<BatchCostingItem> _items;
+
+  @override
+  BatchCostingState build() => BatchCostingState(items: _items);
+}

--- a/test/calculator/provider/calculator_import_values_test.dart
+++ b/test/calculator/provider/calculator_import_values_test.dart
@@ -2,19 +2,28 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:threed_print_cost_calculator/calculator/model/material_usage_input.dart';
 import 'package:threed_print_cost_calculator/calculator/provider/calculator_notifier.dart';
+import 'package:threed_print_cost_calculator/database/repositories/settings_repository.dart';
+import '../../helpers/lower_level_test_fakes.dart' show FakeSettingsRepository;
 
 void main() {
   group('CalculatorProvider.applyImportedValues', () {
+    late FakeSettingsRepository settingsRepo;
     late ProviderContainer container;
     late CalculatorProvider notifier;
 
     setUp(() {
-      container = ProviderContainer();
+      settingsRepo = FakeSettingsRepository();
+      container = ProviderContainer(
+        overrides: [
+          settingsRepositoryProvider.overrideWithValue(settingsRepo),
+        ],
+      );
       notifier = container.read(calculatorProvider.notifier);
     });
 
     tearDown(() {
       container.dispose();
+      settingsRepo.dispose();
     });
 
     test(

--- a/test/calculator/provider/calculator_number_parsing_test.dart
+++ b/test/calculator/provider/calculator_number_parsing_test.dart
@@ -1,19 +1,28 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:threed_print_cost_calculator/calculator/provider/calculator_notifier.dart';
+import 'package:threed_print_cost_calculator/database/repositories/settings_repository.dart';
+import '../../helpers/lower_level_test_fakes.dart' show FakeSettingsRepository;
 
 void main() {
   group('CalculatorProvider localized parsing', () {
+    late FakeSettingsRepository settingsRepo;
     late ProviderContainer container;
     late CalculatorProvider notifier;
 
     setUp(() {
-      container = ProviderContainer();
+      settingsRepo = FakeSettingsRepository();
+      container = ProviderContainer(
+        overrides: [
+          settingsRepositoryProvider.overrideWithValue(settingsRepo),
+        ],
+      );
       notifier = container.read(calculatorProvider.notifier);
     });
 
     tearDown(() {
       container.dispose();
+      settingsRepo.dispose();
     });
 
     test('parses comma-decimal calculator inputs', () {

--- a/test/calculator/provider/calculator_performance_regression_test.dart
+++ b/test/calculator/provider/calculator_performance_regression_test.dart
@@ -3,6 +3,8 @@ import 'package:riverpod/riverpod.dart';
 import 'package:threed_print_cost_calculator/calculator/model/material_usage_input.dart';
 import 'package:threed_print_cost_calculator/calculator/provider/calculator_notifier.dart';
 import 'package:threed_print_cost_calculator/calculator/state/calculation_results_state.dart';
+import 'package:threed_print_cost_calculator/database/repositories/settings_repository.dart';
+import '../../helpers/lower_level_test_fakes.dart' show FakeSettingsRepository;
 
 MaterialUsageInput _usage(int i) => MaterialUsageInput(
   materialId: 'mat-$i',
@@ -41,16 +43,23 @@ CalculationResult _submitAndReadResults(CalculatorProvider notifier) {
 
 void main() {
   group('Calculator performance regressions', () {
+    late FakeSettingsRepository settingsRepo;
     late ProviderContainer container;
     late CalculatorProvider notifier;
 
     setUp(() {
-      container = ProviderContainer();
+      settingsRepo = FakeSettingsRepository();
+      container = ProviderContainer(
+        overrides: [
+          settingsRepositoryProvider.overrideWithValue(settingsRepo),
+        ],
+      );
       notifier = container.read(calculatorProvider.notifier);
     });
 
     tearDown(() {
       container.dispose();
+      settingsRepo.dispose();
     });
 
     test('single material row normalization keeps the total on first row', () {
@@ -102,7 +111,13 @@ void main() {
     });
 
     test('normalized totals match previous row-by-row behavior', () {
-      final oldContainer = ProviderContainer();
+      final oldSettingsRepo = FakeSettingsRepository();
+      addTearDown(oldSettingsRepo.dispose);
+      final oldContainer = ProviderContainer(
+        overrides: [
+          settingsRepositoryProvider.overrideWithValue(oldSettingsRepo),
+        ],
+      );
       addTearDown(oldContainer.dispose);
       final oldNotifier = oldContainer.read(calculatorProvider.notifier);
 


### PR DESCRIPTION
## Summary
- Added batch material assignment with batch-wide and per-item selection, stock warnings, and validation.
- Wired continue flow from material assignment into a minimal pricing scope handoff page.
- Extended batch costing state/notifier to persist material assignment selections.

## ClickUp
- Task: https://app.clickup.com/t/86c9u8ec7
- Status: moved to in progress, then updated to review.
- Status update note: initial attempt to set 'in review' failed because that status does not exist on the list; updated successfully to 'review' instead.

## Tests
- `fvm flutter gen-l10n`
- `fvm flutter analyze`
- `make flutter_test`

## Risks
- Pricing scope page is only a handoff shell for the next ticket.
- Stock warnings depend on material stock tracking being available in the existing materials data.

## Follow-ups
- Implement pricing scope controls in the next batch costing ticket.

## Final verification
- Analyze passed.
- Full Flutter test suite passed.
- Localization regenerated successfully.

## Localization
- Added/updated batch material assignment and pricing scope strings in all supported locales.

## Wiki updates
- None.