### PR TITLE
[86c9vcfkb] Batch costing: save completed batch quote to history

### DIFF
--- a/lib/batch_costing/batch_summary_page.dart
+++ b/lib/batch_costing/batch_summary_page.dart
@@ -1,9 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:bot_toast/bot_toast.dart';
 
 import 'package:threed_print_cost_calculator/batch_costing/providers/batch_costing_notifier.dart';
 import 'package:threed_print_cost_calculator/batch_costing/helpers/batch_summary_calculator.dart';
+import 'package:threed_print_cost_calculator/batch_costing/state/batch_costing_state.dart';
 import 'package:threed_print_cost_calculator/batch_costing/state/batch_pricing_state.dart';
+import 'package:threed_print_cost_calculator/database/repositories/history_repository.dart';
+import 'package:threed_print_cost_calculator/history/history_page.dart';
+import 'package:threed_print_cost_calculator/history/model/history_model.dart';
 import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
 import 'package:threed_print_cost_calculator/shared/providers/batch_costing_visibility.dart';
 import 'package:threed_print_cost_calculator/database/repositories/settings_repository.dart';
@@ -204,6 +209,11 @@ class BatchSummaryPage extends ConsumerWidget {
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 FilledButton(
+                  onPressed: () => _saveQuote(context, ref, state, summary),
+                  child: Text(l10n.batchCostingSummarySaveButton),
+                ),
+                const SizedBox(height: 12),
+                FilledButton(
                   onPressed: () =>
                       Navigator.of(context).popUntil((route) => route.isFirst),
                   child: Text(l10n.batchCostingSummaryReturnToCalculatorButton),
@@ -307,6 +317,64 @@ class BatchSummaryPage extends ConsumerWidget {
 
   Widget _summaryRow(BuildContext context, String label, String value) {
     return _pricingRow(context, label: label, value: value);
+  }
+
+  Future<void> _saveQuote(
+    BuildContext context,
+    WidgetRef ref,
+    BatchCostingState state,
+    BatchSummaryResult summary,
+  ) async {
+    final l10n = AppLocalizations.of(context)!;
+    final model = HistoryModel.batchQuote(
+      name: l10n.batchCostingSummaryDefaultQuoteName,
+      date: DateTime.now(),
+      state: state,
+      summary: summary,
+    );
+
+    try {
+      await ref.read(historyRepositoryProvider).saveHistory(model);
+    } catch (_) {
+      if (!context.mounted) return;
+      BotToast.showText(text: l10n.batchCostingSummarySaveErrorMessage);
+      return;
+    }
+
+    if (!context.mounted) return;
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(l10n.batchCostingSummarySaveSuccessTitle),
+        content: Text(l10n.batchCostingSummarySaveSuccessBody),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              Navigator.of(context).push(
+                MaterialPageRoute<void>(builder: (_) => const HistoryPage()),
+              );
+            },
+            child: Text(l10n.batchCostingSummaryViewHistoryButton),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              Navigator.of(context).popUntil((route) => route.isFirst);
+            },
+            child: Text(l10n.batchCostingSummaryReturnToCalculatorButton),
+          ),
+          FilledButton(
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              ref.read(batchCostingProvider.notifier).reset();
+              Navigator.of(context).popUntil((route) => route.isFirst);
+            },
+            child: Text(l10n.batchCostingSummaryStartNewBatchButton),
+          ),
+        ],
+      ),
+    );
   }
 
   String _pricingSummary(

--- a/lib/history/components/batch_history_item.dart
+++ b/lib/history/components/batch_history_item.dart
@@ -1,0 +1,234 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:threed_print_cost_calculator/history/components/history_item_actions.dart';
+import 'package:threed_print_cost_calculator/history/model/history_model.dart';
+import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
+import 'package:threed_print_cost_calculator/shared/utils/csv_utils.dart';
+
+class BatchHistoryItem extends HookConsumerWidget {
+  const BatchHistoryItem({
+    required this.dbKey,
+    required this.data,
+    required this.itemKeyPrefix,
+    this.onOverflowMenuOpened,
+    this.deleteHistoryEntry,
+    this.exportCsv = exportCSVFile,
+    super.key,
+  });
+
+  final String dbKey;
+  final HistoryModel data;
+  final String itemKeyPrefix;
+  final VoidCallback? onOverflowMenuOpened;
+  final Future<void> Function(WidgetRef ref, String dbKey)? deleteHistoryEntry;
+  final HistoryItemExportCsv exportCsv;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context)!;
+    final summary = data.batchQuoteSummary ?? const <String, dynamic>{};
+    final items = data.batchQuoteItems;
+    return Container(
+      key: ValueKey<String>('$itemKeyPrefix.card'),
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: const Color.fromRGBO(8, 8, 18, 1),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(
+                key: ValueKey<String>('$itemKeyPrefix.name'),
+                data.name,
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+              const Spacer(),
+              HistoryItemActions(
+                dbKey: dbKey,
+                data: data,
+                itemKeyPrefix: itemKeyPrefix,
+                onOverflowMenuOpened: onOverflowMenuOpened,
+                deleteHistoryEntry: deleteHistoryEntry,
+                exportCsv: exportCsv,
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            l10n.batchHistorySummaryLine(
+              '${summary['itemCount'] ?? 0}',
+              '${summary['totalQuantity'] ?? 0}',
+            ),
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          const SizedBox(height: 8),
+          _detailRow(
+            context,
+            l10n.batchCostingSummaryFinalTotalLabel,
+            data.totalCost.toStringAsFixed(2),
+          ),
+          _detailRow(
+            context,
+            l10n.batchCostingSummaryTotalWeightLabel,
+            '${data.weight.toStringAsFixed(2)} ${l10n.gramsSuffix}',
+          ),
+          _detailRow(
+            context,
+            l10n.batchCostingSummaryTotalDurationLabel,
+            data.timeHours,
+          ),
+          const SizedBox(height: 8),
+          ExpansionTile(
+            tilePadding: EdgeInsets.zero,
+            childrenPadding: const EdgeInsets.only(left: 4, right: 4),
+            title: Text(
+              l10n.batchCostingSummaryPricingTitle,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Colors.white70,
+                  ),
+            ),
+            children: [
+              _detailRow(
+                context,
+                l10n.failureRiskLabel,
+                _pricingString(summary, 'failureRisk'),
+              ),
+              _detailRow(
+                context,
+                l10n.pricingMarkupPercentLabel,
+                _pricingString(summary, 'markupPercent'),
+              ),
+              _detailRow(
+                context,
+                l10n.labourRateLabel,
+                _pricingString(summary, 'labourRate'),
+              ),
+              _detailRow(
+                context,
+                l10n.additionalCostLabel,
+                _pricingString(summary, 'additionalCostAmount'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          ExpansionTile(
+            tilePadding: EdgeInsets.zero,
+            childrenPadding: const EdgeInsets.only(left: 4, right: 4),
+            title: Text(
+              l10n.batchHistoryItemsTitle,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Colors.white70,
+                  ),
+            ),
+            children: [
+              for (final item in items)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: const Color.fromRGBO(255, 255, 255, 0.04),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.all(8),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '${item['name']?.toString() ?? ''} × ${item['quantity']?.toString() ?? '0'}',
+                            style: Theme.of(context).textTheme.bodyMedium
+                                ?.copyWith(color: Colors.white),
+                          ),
+                          const SizedBox(height: 4),
+                          _detailRow(
+                            context,
+                            l10n.batchCostingSummaryItemWeightLabel,
+                            '${item['totalWeightG']?.toString() ?? '0'} ${l10n.gramsSuffix}',
+                          ),
+                          _detailRow(
+                            context,
+                            l10n.batchCostingSummaryItemDurationLabel,
+                            _formatDurationFromMinutes(
+                              item['totalPrintDurationMinutes'],
+                            ),
+                          ),
+                          _detailRow(
+                            context,
+                            l10n.batchCostingSummaryItemBaseCostLabel,
+                            _amountString(item['baseCost']),
+                          ),
+                          _detailRow(
+                            context,
+                            l10n.batchCostingSummaryItemAdjustmentLabel,
+                            _amountString(item['additionalCost']),
+                          ),
+                          _detailRow(
+                            context,
+                            l10n.batchCostingSummaryItemTotalLabel,
+                            _amountString(item['finalTotal']),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _detailRow(BuildContext context, String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              label,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Colors.white70,
+                  ),
+            ),
+          ),
+          Text(
+            value,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Colors.white,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _pricingString(Map<String, dynamic> summary, String key) {
+    final pricing = summary['pricing'];
+    if (pricing is! Map) return '—';
+    final field = pricing[key];
+    if (field is! Map) return '—';
+    final value = field['value']?.toString() ?? '0';
+    final scope = field['scope']?.toString();
+    return scope == null || scope.isEmpty ? value : '$value ($scope)';
+  }
+
+  String _amountString(dynamic raw) {
+    if (raw is num) return raw.toStringAsFixed(2);
+    return num.tryParse(raw?.toString() ?? '')?.toStringAsFixed(2) ?? '0.00';
+  }
+
+  String _formatDurationFromMinutes(dynamic minutesValue) {
+    final minutes = int.tryParse(minutesValue?.toString() ?? '') ?? 0;
+    final hours = minutes ~/ 60;
+    final mins = minutes.remainder(60);
+    return '${hours.toString().padLeft(2, '0')}:${mins.toString().padLeft(2, '0')}';
+  }
+}

--- a/lib/history/components/history_item.dart
+++ b/lib/history/components/history_item.dart
@@ -7,6 +7,7 @@ import 'package:threed_print_cost_calculator/history/components/history_item_hea
 import 'package:threed_print_cost_calculator/history/components/history_item_material_breakdown.dart';
 import 'package:threed_print_cost_calculator/history/components/history_item_slidable_wrapper.dart';
 import 'package:threed_print_cost_calculator/history/components/history_item_summary.dart';
+import 'package:threed_print_cost_calculator/history/components/batch_history_item.dart';
 import 'package:threed_print_cost_calculator/history/model/history_model.dart';
 import 'package:threed_print_cost_calculator/l10n/app_localizations.dart';
 import 'package:threed_print_cost_calculator/shared/utils/csv_utils.dart';
@@ -46,39 +47,48 @@ class HistoryItem extends HookConsumerWidget {
       dbKey: dbKey,
       deleteLabel: l10n.deleteButton,
       onDelete: () => actionsController.deleteEntry(context, ref),
-      child: Container(
-        key: ValueKey<String>('$itemKeyPrefix.card'),
-        padding: const EdgeInsets.all(8),
-        decoration: BoxDecoration(
-          color: const Color.fromRGBO(8, 8, 18, 1),
-          borderRadius: BorderRadius.circular(8),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            HistoryItemHeader(
+      child: data.batchQuote
+          ? BatchHistoryItem(
               dbKey: dbKey,
               data: data,
               itemKeyPrefix: itemKeyPrefix,
-              onHistoryLoaded: onHistoryLoaded,
               onOverflowMenuOpened: onOverflowMenuOpened,
               deleteHistoryEntry: deleteHistoryEntry,
               exportCsv: exportCsv,
-            ),
-            const SizedBox(height: 8),
-            HistoryItemCostRows(data: data, itemKeyPrefix: itemKeyPrefix),
-            const SizedBox(height: 4),
-            const Divider(),
-            const SizedBox(height: 4),
-            HistoryItemSummary(data: data, itemKeyPrefix: itemKeyPrefix),
-            if (data.materialUsages.isNotEmpty)
-              HistoryItemMaterialBreakdown(
-                materialUsages: data.materialUsages,
-                materialsById: materialsById,
+            )
+          : Container(
+              key: ValueKey<String>('$itemKeyPrefix.card'),
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: const Color.fromRGBO(8, 8, 18, 1),
+                borderRadius: BorderRadius.circular(8),
               ),
-          ],
-        ),
-      ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  HistoryItemHeader(
+                    dbKey: dbKey,
+                    data: data,
+                    itemKeyPrefix: itemKeyPrefix,
+                    onHistoryLoaded: onHistoryLoaded,
+                    onOverflowMenuOpened: onOverflowMenuOpened,
+                    deleteHistoryEntry: deleteHistoryEntry,
+                    exportCsv: exportCsv,
+                  ),
+                  const SizedBox(height: 8),
+                  HistoryItemCostRows(data: data, itemKeyPrefix: itemKeyPrefix),
+                  const SizedBox(height: 4),
+                  const Divider(),
+                  const SizedBox(height: 4),
+                  HistoryItemSummary(data: data, itemKeyPrefix: itemKeyPrefix),
+                  if (data.materialUsages.isNotEmpty)
+                    HistoryItemMaterialBreakdown(
+                      materialUsages: data.materialUsages,
+                      materialsById: materialsById,
+                    ),
+                ],
+              ),
+            ),
     );
   }
 }

--- a/lib/history/components/history_item_actions.dart
+++ b/lib/history/components/history_item_actions.dart
@@ -171,16 +171,17 @@ class HistoryItemActions extends ConsumerWidget {
         }
       },
       itemBuilder: (context) => [
-        PopupMenuItem<_HistoryItemAction>(
-          value: _HistoryItemAction.edit,
-          child: Row(
-            children: [
-              const Icon(Icons.calculate, size: 20),
-              const SizedBox(width: 12),
-              Flexible(child: Text(l10n.historyLoadAction)),
-            ],
+        if (!data.batchQuote)
+          PopupMenuItem<_HistoryItemAction>(
+            value: _HistoryItemAction.edit,
+            child: Row(
+              children: [
+                const Icon(Icons.calculate, size: 20),
+                const SizedBox(width: 12),
+                Flexible(child: Text(l10n.historyLoadAction)),
+              ],
+            ),
           ),
-        ),
         PopupMenuItem<_HistoryItemAction>(
           value: _HistoryItemAction.export,
           child: Row(

--- a/lib/history/model/history_model.dart
+++ b/lib/history/model/history_model.dart
@@ -1,4 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:threed_print_cost_calculator/batch_costing/helpers/batch_summary_calculator.dart';
+import 'package:threed_print_cost_calculator/batch_costing/state/batch_costing_state.dart';
+import 'package:threed_print_cost_calculator/batch_costing/state/batch_pricing_state.dart';
 import 'package:threed_print_cost_calculator/shared/constants.dart';
 import 'package:threed_print_cost_calculator/shared/utils/number_parsing.dart';
 
@@ -31,7 +34,53 @@ abstract class HistoryModel with _$HistoryModel {
     num? pricingRoundingAdjustment,
     num? finalPrice,
     bool? pricingUsedOverrides,
+    @Default(false) bool batchQuote,
+    @Default(<Map<String, dynamic>>[]) List<Map<String, dynamic>> batchQuoteItems,
+    Map<String, dynamic>? batchQuoteSummary,
   }) = _HistoryModel;
+
+  factory HistoryModel.batchQuote({
+    required String name,
+    required DateTime date,
+    required BatchCostingState state,
+    required BatchSummaryResult summary,
+  }) {
+    return HistoryModel(
+      name: name,
+      totalCost: summary.finalTotal,
+      riskCost: _pricingValue(state.pricing.failureRisk),
+      filamentCost: 0,
+      electricityCost: 0,
+      labourCost: 0,
+      additionalCostAmount: summary.additionalCost,
+      date: date,
+      printer: state.batchPrinterId ?? kUnassignedLabel,
+      material: state.batchMaterialId ?? kUnassignedLabel,
+      weight: summary.totalWeightG,
+      timeHours: _formatDuration(summary.totalPrintDuration),
+      batchQuote: true,
+      batchQuoteItems: summary.items.map(_batchItemToMap).toList(),
+      batchQuoteSummary: {
+        'itemCount': summary.itemCount,
+        'totalQuantity': summary.totalQuantity,
+        'totalWeightG': summary.totalWeightG,
+        'totalPrintDurationMinutes': summary.totalPrintDuration.inMinutes,
+        'finalTotal': summary.finalTotal,
+        'printerAssignmentMode': state.printerAssignmentMode.name,
+        'materialAssignmentMode': state.materialAssignmentMode.name,
+        'batchPrinterId': state.batchPrinterId,
+        'batchMaterialId': state.batchMaterialId,
+        'pricing': {
+          'failureRisk': _pricingFieldToMap(state.pricing.failureRisk),
+          'markupPercent': _pricingFieldToMap(state.pricing.markupPercent),
+          'labourRate': _pricingFieldToMap(state.pricing.labourRate),
+          'additionalCostAmount': _pricingFieldToMap(
+            state.pricing.additionalCostAmount,
+          ),
+        },
+      },
+    );
+  }
 
   factory HistoryModel.fromMap(Map<String, dynamic> map) {
     final dynamic dateValue = map['date'];
@@ -74,6 +123,9 @@ abstract class HistoryModel with _$HistoryModel {
       pricingUsedOverrides: map['pricingUsedOverrides'] == null
           ? null
           : map['pricingUsedOverrides'] == true,
+      batchQuote: map['batchQuote'] == true,
+      batchQuoteItems: _parseMapList(map['batchQuoteItems']),
+      batchQuoteSummary: _parseMap(map['batchQuoteSummary']),
     );
   }
 
@@ -88,6 +140,59 @@ abstract class HistoryModel with _$HistoryModel {
         .whereType<Map>()
         .map((e) => e.map((k, v) => MapEntry(k.toString(), v)))
         .toList();
+  }
+
+  static List<Map<String, dynamic>> _parseMapList(dynamic raw) {
+    if (raw is! List) return const [];
+    return raw
+        .whereType<Map>()
+        .map((e) => e.map((k, v) => MapEntry(k.toString(), v)))
+        .toList();
+  }
+
+  static Map<String, dynamic>? _parseMap(dynamic raw) {
+    if (raw is! Map) return null;
+    return raw.map((k, v) => MapEntry(k.toString(), v));
+  }
+
+  static Map<String, dynamic> _batchItemToMap(
+    BatchSummaryItemBreakdown breakdown,
+  ) {
+    return {
+      'id': breakdown.item.id,
+      'name': breakdown.item.displayName,
+      'quantity': breakdown.totalQuantity,
+      'printerId': breakdown.item.printerId,
+      'materialId': breakdown.item.materialId,
+      'pricingProfileId': breakdown.item.pricingProfileId,
+      'totalWeightG': breakdown.totalWeightG,
+      'totalPrintDurationMinutes': breakdown.totalPrintDuration.inMinutes,
+      'baseCost': breakdown.baseCost,
+      'additionalCost': breakdown.additionalCost,
+      'finalTotal': breakdown.pricing.finalPrice,
+      'pricing': {
+        'markupPercent': breakdown.pricing.markupPercent,
+        'setupFee': breakdown.pricing.setupFee,
+        'subtotalBeforeRounding': breakdown.pricing.subtotalBeforeRounding,
+        'roundingAdjustment': breakdown.pricing.roundingAdjustment,
+      },
+    };
+  }
+
+  static Map<String, dynamic> _pricingFieldToMap(
+    BatchPricingFieldState field,
+  ) {
+    return {'value': field.value, 'scope': field.scope.name};
+  }
+
+  static num _pricingValue(BatchPricingFieldState field) {
+    return num.tryParse(field.value.replaceAll(',', '.')) ?? 0;
+  }
+
+  static String _formatDuration(Duration duration) {
+    final hours = duration.inHours.toString().padLeft(2, '0');
+    final minutes = duration.inMinutes.remainder(60).toString().padLeft(2, '0');
+    return '$hours:$minutes';
   }
 }
 
@@ -117,6 +222,9 @@ extension HistoryModelX on HistoryModel {
       'pricingRoundingAdjustment': pricingRoundingAdjustment,
       'finalPrice': finalPrice,
       'pricingUsedOverrides': pricingUsedOverrides,
+      'batchQuote': batchQuote,
+      'batchQuoteItems': batchQuoteItems,
+      'batchQuoteSummary': batchQuoteSummary,
     };
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -984,6 +984,60 @@ abstract class AppLocalizations {
   /// **'Enable batch costing'**
   String get enableBatchCostingButton;
 
+  /// No description provided for @batchCostingSummarySaveButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Save quote'**
+  String get batchCostingSummarySaveButton;
+
+  /// No description provided for @batchCostingSummarySaveSuccessTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Quote saved'**
+  String get batchCostingSummarySaveSuccessTitle;
+
+  /// No description provided for @batchCostingSummarySaveSuccessBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Saved to history.'**
+  String get batchCostingSummarySaveSuccessBody;
+
+  /// No description provided for @batchCostingSummaryViewHistoryButton.
+  ///
+  /// In en, this message translates to:
+  /// **'View history'**
+  String get batchCostingSummaryViewHistoryButton;
+
+  /// No description provided for @batchCostingSummarySaveErrorMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not save quote'**
+  String get batchCostingSummarySaveErrorMessage;
+
+  /// No description provided for @batchCostingSummaryDefaultQuoteName.
+  ///
+  /// In en, this message translates to:
+  /// **'Batch quote'**
+  String get batchCostingSummaryDefaultQuoteName;
+
+  /// No description provided for @batchHistoryItemsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Batch items'**
+  String get batchHistoryItemsTitle;
+
+  /// No description provided for @batchHistorySummaryLine.
+  ///
+  /// In en, this message translates to:
+  /// **'{itemCount} items • {totalQuantity} copies'**
+  String batchHistorySummaryLine(Object itemCount, Object totalQuantity);
+
+  /// No description provided for @batchHistoryItemRow.
+  ///
+  /// In en, this message translates to:
+  /// **'{name} × {quantity}'**
+  String batchHistoryItemRow(Object name, Object quantity);
+
   /// No description provided for @showWhatsNewButton.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -475,6 +475,37 @@ class AppLocalizationsDe extends AppLocalizations {
   String get enableBatchCostingButton => 'Enable batch costing';
 
   @override
+  String get batchCostingSummarySaveButton => 'Save quote';
+
+  @override
+  String get batchCostingSummarySaveSuccessTitle => 'Quote saved';
+
+  @override
+  String get batchCostingSummarySaveSuccessBody => 'Saved to history.';
+
+  @override
+  String get batchCostingSummaryViewHistoryButton => 'View history';
+
+  @override
+  String get batchCostingSummarySaveErrorMessage => 'Could not save quote';
+
+  @override
+  String get batchCostingSummaryDefaultQuoteName => 'Batch quote';
+
+  @override
+  String get batchHistoryItemsTitle => 'Batch items';
+
+  @override
+  String batchHistorySummaryLine(Object itemCount, Object totalQuantity) {
+    return '$itemCount items • $totalQuantity copies';
+  }
+
+  @override
+  String batchHistoryItemRow(Object name, Object quantity) {
+    return '$name × $quantity';
+  }
+
+  @override
   String get showWhatsNewButton => 'Show What\'s New';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -473,6 +473,37 @@ class AppLocalizationsEn extends AppLocalizations {
   String get enableBatchCostingButton => 'Enable batch costing';
 
   @override
+  String get batchCostingSummarySaveButton => 'Save quote';
+
+  @override
+  String get batchCostingSummarySaveSuccessTitle => 'Quote saved';
+
+  @override
+  String get batchCostingSummarySaveSuccessBody => 'Saved to history.';
+
+  @override
+  String get batchCostingSummaryViewHistoryButton => 'View history';
+
+  @override
+  String get batchCostingSummarySaveErrorMessage => 'Could not save quote';
+
+  @override
+  String get batchCostingSummaryDefaultQuoteName => 'Batch quote';
+
+  @override
+  String get batchHistoryItemsTitle => 'Batch items';
+
+  @override
+  String batchHistorySummaryLine(Object itemCount, Object totalQuantity) {
+    return '$itemCount items • $totalQuantity copies';
+  }
+
+  @override
+  String batchHistoryItemRow(Object name, Object quantity) {
+    return '$name × $quantity';
+  }
+
+  @override
   String get showWhatsNewButton => 'Show What\'s New';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -477,6 +477,37 @@ class AppLocalizationsEs extends AppLocalizations {
   String get enableBatchCostingButton => 'Enable batch costing';
 
   @override
+  String get batchCostingSummarySaveButton => 'Save quote';
+
+  @override
+  String get batchCostingSummarySaveSuccessTitle => 'Quote saved';
+
+  @override
+  String get batchCostingSummarySaveSuccessBody => 'Saved to history.';
+
+  @override
+  String get batchCostingSummaryViewHistoryButton => 'View history';
+
+  @override
+  String get batchCostingSummarySaveErrorMessage => 'Could not save quote';
+
+  @override
+  String get batchCostingSummaryDefaultQuoteName => 'Batch quote';
+
+  @override
+  String get batchHistoryItemsTitle => 'Batch items';
+
+  @override
+  String batchHistorySummaryLine(Object itemCount, Object totalQuantity) {
+    return '$itemCount items • $totalQuantity copies';
+  }
+
+  @override
+  String batchHistoryItemRow(Object name, Object quantity) {
+    return '$name × $quantity';
+  }
+
+  @override
   String get showWhatsNewButton => 'Show What\'s New';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -480,6 +480,37 @@ class AppLocalizationsFr extends AppLocalizations {
   String get enableBatchCostingButton => 'Enable batch costing';
 
   @override
+  String get batchCostingSummarySaveButton => 'Save quote';
+
+  @override
+  String get batchCostingSummarySaveSuccessTitle => 'Quote saved';
+
+  @override
+  String get batchCostingSummarySaveSuccessBody => 'Saved to history.';
+
+  @override
+  String get batchCostingSummaryViewHistoryButton => 'View history';
+
+  @override
+  String get batchCostingSummarySaveErrorMessage => 'Could not save quote';
+
+  @override
+  String get batchCostingSummaryDefaultQuoteName => 'Batch quote';
+
+  @override
+  String get batchHistoryItemsTitle => 'Batch items';
+
+  @override
+  String batchHistorySummaryLine(Object itemCount, Object totalQuantity) {
+    return '$itemCount items • $totalQuantity copies';
+  }
+
+  @override
+  String batchHistoryItemRow(Object name, Object quantity) {
+    return '$name × $quantity';
+  }
+
+  @override
   String get showWhatsNewButton => 'Show What\'s New';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -475,6 +475,37 @@ class AppLocalizationsId extends AppLocalizations {
   String get enableBatchCostingButton => 'Enable batch costing';
 
   @override
+  String get batchCostingSummarySaveButton => 'Save quote';
+
+  @override
+  String get batchCostingSummarySaveSuccessTitle => 'Quote saved';
+
+  @override
+  String get batchCostingSummarySaveSuccessBody => 'Saved to history.';
+
+  @override
+  String get batchCostingSummaryViewHistoryButton => 'View history';
+
+  @override
+  String get batchCostingSummarySaveErrorMessage => 'Could not save quote';
+
+  @override
+  String get batchCostingSummaryDefaultQuoteName => 'Batch quote';
+
+  @override
+  String get batchHistoryItemsTitle => 'Batch items';
+
+  @override
+  String batchHistorySummaryLine(Object itemCount, Object totalQuantity) {
+    return '$itemCount items • $totalQuantity copies';
+  }
+
+  @override
+  String batchHistoryItemRow(Object name, Object quantity) {
+    return '$name × $quantity';
+  }
+
+  @override
   String get showWhatsNewButton => 'Show What\'s New';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -478,6 +478,37 @@ class AppLocalizationsIt extends AppLocalizations {
   String get enableBatchCostingButton => 'Enable batch costing';
 
   @override
+  String get batchCostingSummarySaveButton => 'Save quote';
+
+  @override
+  String get batchCostingSummarySaveSuccessTitle => 'Quote saved';
+
+  @override
+  String get batchCostingSummarySaveSuccessBody => 'Saved to history.';
+
+  @override
+  String get batchCostingSummaryViewHistoryButton => 'View history';
+
+  @override
+  String get batchCostingSummarySaveErrorMessage => 'Could not save quote';
+
+  @override
+  String get batchCostingSummaryDefaultQuoteName => 'Batch quote';
+
+  @override
+  String get batchHistoryItemsTitle => 'Batch items';
+
+  @override
+  String batchHistorySummaryLine(Object itemCount, Object totalQuantity) {
+    return '$itemCount items • $totalQuantity copies';
+  }
+
+  @override
+  String batchHistoryItemRow(Object name, Object quantity) {
+    return '$name × $quantity';
+  }
+
+  @override
   String get showWhatsNewButton => 'Show What\'s New';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -464,6 +464,37 @@ class AppLocalizationsJa extends AppLocalizations {
   String get enableBatchCostingButton => 'Enable batch costing';
 
   @override
+  String get batchCostingSummarySaveButton => 'Save quote';
+
+  @override
+  String get batchCostingSummarySaveSuccessTitle => 'Quote saved';
+
+  @override
+  String get batchCostingSummarySaveSuccessBody => 'Saved to history.';
+
+  @override
+  String get batchCostingSummaryViewHistoryButton => 'View history';
+
+  @override
+  String get batchCostingSummarySaveErrorMessage => 'Could not save quote';
+
+  @override
+  String get batchCostingSummaryDefaultQuoteName => 'Batch quote';
+
+  @override
+  String get batchHistoryItemsTitle => 'Batch items';
+
+  @override
+  String batchHistorySummaryLine(Object itemCount, Object totalQuantity) {
+    return '$itemCount items • $totalQuantity copies';
+  }
+
+  @override
+  String batchHistoryItemRow(Object name, Object quantity) {
+    return '$name × $quantity';
+  }
+
+  @override
   String get showWhatsNewButton => 'Show What\'s New';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -475,6 +475,37 @@ class AppLocalizationsNl extends AppLocalizations {
   String get enableBatchCostingButton => 'Enable batch costing';
 
   @override
+  String get batchCostingSummarySaveButton => 'Save quote';
+
+  @override
+  String get batchCostingSummarySaveSuccessTitle => 'Quote saved';
+
+  @override
+  String get batchCostingSummarySaveSuccessBody => 'Saved to history.';
+
+  @override
+  String get batchCostingSummaryViewHistoryButton => 'View history';
+
+  @override
+  String get batchCostingSummarySaveErrorMessage => 'Could not save quote';
+
+  @override
+  String get batchCostingSummaryDefaultQuoteName => 'Batch quote';
+
+  @override
+  String get batchHistoryItemsTitle => 'Batch items';
+
+  @override
+  String batchHistorySummaryLine(Object itemCount, Object totalQuantity) {
+    return '$itemCount items • $totalQuantity copies';
+  }
+
+  @override
+  String batchHistoryItemRow(Object name, Object quantity) {
+    return '$name × $quantity';
+  }
+
+  @override
   String get showWhatsNewButton => 'Show What\'s New';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -476,6 +476,37 @@ class AppLocalizationsPt extends AppLocalizations {
   String get enableBatchCostingButton => 'Enable batch costing';
 
   @override
+  String get batchCostingSummarySaveButton => 'Save quote';
+
+  @override
+  String get batchCostingSummarySaveSuccessTitle => 'Quote saved';
+
+  @override
+  String get batchCostingSummarySaveSuccessBody => 'Saved to history.';
+
+  @override
+  String get batchCostingSummaryViewHistoryButton => 'View history';
+
+  @override
+  String get batchCostingSummarySaveErrorMessage => 'Could not save quote';
+
+  @override
+  String get batchCostingSummaryDefaultQuoteName => 'Batch quote';
+
+  @override
+  String get batchHistoryItemsTitle => 'Batch items';
+
+  @override
+  String batchHistorySummaryLine(Object itemCount, Object totalQuantity) {
+    return '$itemCount items • $totalQuantity copies';
+  }
+
+  @override
+  String batchHistoryItemRow(Object name, Object quantity) {
+    return '$name × $quantity';
+  }
+
+  @override
   String get showWhatsNewButton => 'Show What\'s New';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -471,6 +471,37 @@ class AppLocalizationsTh extends AppLocalizations {
   String get enableBatchCostingButton => 'Enable batch costing';
 
   @override
+  String get batchCostingSummarySaveButton => 'Save quote';
+
+  @override
+  String get batchCostingSummarySaveSuccessTitle => 'Quote saved';
+
+  @override
+  String get batchCostingSummarySaveSuccessBody => 'Saved to history.';
+
+  @override
+  String get batchCostingSummaryViewHistoryButton => 'View history';
+
+  @override
+  String get batchCostingSummarySaveErrorMessage => 'Could not save quote';
+
+  @override
+  String get batchCostingSummaryDefaultQuoteName => 'Batch quote';
+
+  @override
+  String get batchHistoryItemsTitle => 'Batch items';
+
+  @override
+  String batchHistorySummaryLine(Object itemCount, Object totalQuantity) {
+    return '$itemCount items • $totalQuantity copies';
+  }
+
+  @override
+  String batchHistoryItemRow(Object name, Object quantity) {
+    return '$name × $quantity';
+  }
+
+  @override
   String get showWhatsNewButton => 'Show What\'s New';
 
   @override

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -335,6 +335,27 @@
   "clearUpdateCooldownButton": "Update-Wartezeit löschen",
   "previewCancelFeedbackButton": "Rückmeldeansicht zur Verlängerung",
   "enableBatchCostingButton": "Enable batch costing",
+  "batchCostingSummarySaveButton": "Save quote",
+  "batchCostingSummarySaveSuccessTitle": "Quote saved",
+  "batchCostingSummarySaveSuccessBody": "Saved to history.",
+  "batchCostingSummaryViewHistoryButton": "View history",
+  "batchCostingSummarySaveErrorMessage": "Could not save quote",
+  "batchCostingSummaryDefaultQuoteName": "Batch quote",
+  "batchHistoryItemsTitle": "Batch items",
+  "batchHistorySummaryLine": "{itemCount} items • {totalQuantity} copies",
+  "@batchHistorySummaryLine": {
+    "placeholders": {
+      "itemCount": {},
+      "totalQuantity": {}
+    }
+  },
+  "batchHistoryItemRow": "{name} × {quantity}",
+  "@batchHistoryItemRow": {
+    "placeholders": {
+      "name": {},
+      "quantity": {}
+    }
+  },
   "showWhatsNewButton": "Show What's New",
   "enablePremiumTitle": "Premium aktivieren",
   "enablePremiumBody": "Bestätigungscode eingeben, um lokale Premium-Tests zu aktivieren",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -190,6 +190,27 @@
   "clearUpdateCooldownButton": "Clear update cooldown",
   "previewCancelFeedbackButton": "Preview renewal feedback",
   "enableBatchCostingButton": "Enable batch costing",
+  "batchCostingSummarySaveButton": "Save quote",
+  "batchCostingSummarySaveSuccessTitle": "Quote saved",
+  "batchCostingSummarySaveSuccessBody": "Saved to history.",
+  "batchCostingSummaryViewHistoryButton": "View history",
+  "batchCostingSummarySaveErrorMessage": "Could not save quote",
+  "batchCostingSummaryDefaultQuoteName": "Batch quote",
+  "batchHistoryItemsTitle": "Batch items",
+  "batchHistorySummaryLine": "{itemCount} items • {totalQuantity} copies",
+  "@batchHistorySummaryLine": {
+    "placeholders": {
+      "itemCount": {},
+      "totalQuantity": {}
+    }
+  },
+  "batchHistoryItemRow": "{name} × {quantity}",
+  "@batchHistoryItemRow": {
+    "placeholders": {
+      "name": {},
+      "quantity": {}
+    }
+  },
   "showWhatsNewButton": "Show What's New",
   "enablePremiumTitle": "Enable premium",
   "enablePremiumBody": "Enter confirmation code to enable local premium testing",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -328,6 +328,27 @@
   "clearUpdateCooldownButton": "Borrar pausa de actualización",
   "previewCancelFeedbackButton": "Vista previa de comentarios de cancelación",
   "enableBatchCostingButton": "Enable batch costing",
+  "batchCostingSummarySaveButton": "Save quote",
+  "batchCostingSummarySaveSuccessTitle": "Quote saved",
+  "batchCostingSummarySaveSuccessBody": "Saved to history.",
+  "batchCostingSummaryViewHistoryButton": "View history",
+  "batchCostingSummarySaveErrorMessage": "Could not save quote",
+  "batchCostingSummaryDefaultQuoteName": "Batch quote",
+  "batchHistoryItemsTitle": "Batch items",
+  "batchHistorySummaryLine": "{itemCount} items • {totalQuantity} copies",
+  "@batchHistorySummaryLine": {
+    "placeholders": {
+      "itemCount": {},
+      "totalQuantity": {}
+    }
+  },
+  "batchHistoryItemRow": "{name} × {quantity}",
+  "@batchHistoryItemRow": {
+    "placeholders": {
+      "name": {},
+      "quantity": {}
+    }
+  },
   "showWhatsNewButton": "Show What's New",
   "enablePremiumTitle": "Activar premium",
   "enablePremiumBody": "Introduce el código de confirmación para activar las pruebas locales de premium",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -337,6 +337,27 @@
   "clearUpdateCooldownButton": "Effacer le délai de mise à jour",
   "previewCancelFeedbackButton": "Aperçu des commentaires d'annulation",
   "enableBatchCostingButton": "Enable batch costing",
+  "batchCostingSummarySaveButton": "Save quote",
+  "batchCostingSummarySaveSuccessTitle": "Quote saved",
+  "batchCostingSummarySaveSuccessBody": "Saved to history.",
+  "batchCostingSummaryViewHistoryButton": "View history",
+  "batchCostingSummarySaveErrorMessage": "Could not save quote",
+  "batchCostingSummaryDefaultQuoteName": "Batch quote",
+  "batchHistoryItemsTitle": "Batch items",
+  "batchHistorySummaryLine": "{itemCount} items • {totalQuantity} copies",
+  "@batchHistorySummaryLine": {
+    "placeholders": {
+      "itemCount": {},
+      "totalQuantity": {}
+    }
+  },
+  "batchHistoryItemRow": "{name} × {quantity}",
+  "@batchHistoryItemRow": {
+    "placeholders": {
+      "name": {},
+      "quantity": {}
+    }
+  },
   "showWhatsNewButton": "Show What's New",
   "enablePremiumTitle": "Activer le premium",
   "enablePremiumBody": "Saisissez le code de confirmation pour activer les tests premium locaux",

--- a/lib/l10n/intl_id.arb
+++ b/lib/l10n/intl_id.arb
@@ -329,6 +329,27 @@
   "clearUpdateCooldownButton": "Hapus jeda pembaruan",
   "previewCancelFeedbackButton": "Pratinjau umpan balik pembatalan",
   "enableBatchCostingButton": "Enable batch costing",
+  "batchCostingSummarySaveButton": "Save quote",
+  "batchCostingSummarySaveSuccessTitle": "Quote saved",
+  "batchCostingSummarySaveSuccessBody": "Saved to history.",
+  "batchCostingSummaryViewHistoryButton": "View history",
+  "batchCostingSummarySaveErrorMessage": "Could not save quote",
+  "batchCostingSummaryDefaultQuoteName": "Batch quote",
+  "batchHistoryItemsTitle": "Batch items",
+  "batchHistorySummaryLine": "{itemCount} items • {totalQuantity} copies",
+  "@batchHistorySummaryLine": {
+    "placeholders": {
+      "itemCount": {},
+      "totalQuantity": {}
+    }
+  },
+  "batchHistoryItemRow": "{name} × {quantity}",
+  "@batchHistoryItemRow": {
+    "placeholders": {
+      "name": {},
+      "quantity": {}
+    }
+  },
   "showWhatsNewButton": "Show What's New",
   "enablePremiumTitle": "Aktifkan premium",
   "enablePremiumBody": "Masukkan kode konfirmasi untuk mengaktifkan pengujian premium lokal",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -329,6 +329,27 @@
   "clearUpdateCooldownButton": "Cancella attesa aggiornamento",
   "previewCancelFeedbackButton": "Anteprima feedback annullamento",
   "enableBatchCostingButton": "Enable batch costing",
+  "batchCostingSummarySaveButton": "Save quote",
+  "batchCostingSummarySaveSuccessTitle": "Quote saved",
+  "batchCostingSummarySaveSuccessBody": "Saved to history.",
+  "batchCostingSummaryViewHistoryButton": "View history",
+  "batchCostingSummarySaveErrorMessage": "Could not save quote",
+  "batchCostingSummaryDefaultQuoteName": "Batch quote",
+  "batchHistoryItemsTitle": "Batch items",
+  "batchHistorySummaryLine": "{itemCount} items • {totalQuantity} copies",
+  "@batchHistorySummaryLine": {
+    "placeholders": {
+      "itemCount": {},
+      "totalQuantity": {}
+    }
+  },
+  "batchHistoryItemRow": "{name} × {quantity}",
+  "@batchHistoryItemRow": {
+    "placeholders": {
+      "name": {},
+      "quantity": {}
+    }
+  },
   "showWhatsNewButton": "Show What's New",
   "enablePremiumTitle": "Attiva premium",
   "enablePremiumBody": "Inserisci il codice di conferma per attivare i test premium locali",

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -337,6 +337,27 @@
   "clearUpdateCooldownButton": "更新クールダウンを消去",
   "previewCancelFeedbackButton": "取消フィードバックをプレビュー",
   "enableBatchCostingButton": "Enable batch costing",
+  "batchCostingSummarySaveButton": "Save quote",
+  "batchCostingSummarySaveSuccessTitle": "Quote saved",
+  "batchCostingSummarySaveSuccessBody": "Saved to history.",
+  "batchCostingSummaryViewHistoryButton": "View history",
+  "batchCostingSummarySaveErrorMessage": "Could not save quote",
+  "batchCostingSummaryDefaultQuoteName": "Batch quote",
+  "batchHistoryItemsTitle": "Batch items",
+  "batchHistorySummaryLine": "{itemCount} items • {totalQuantity} copies",
+  "@batchHistorySummaryLine": {
+    "placeholders": {
+      "itemCount": {},
+      "totalQuantity": {}
+    }
+  },
+  "batchHistoryItemRow": "{name} × {quantity}",
+  "@batchHistoryItemRow": {
+    "placeholders": {
+      "name": {},
+      "quantity": {}
+    }
+  },
   "showWhatsNewButton": "Show What's New",
   "enablePremiumTitle": "プレミアムを有効化",
   "enablePremiumBody": "ローカルのプレミアムテストを有効にする確認コードを入力してください",

--- a/lib/l10n/intl_nl.arb
+++ b/lib/l10n/intl_nl.arb
@@ -337,6 +337,27 @@
   "clearUpdateCooldownButton": "Update-afkoeling wissen",
   "previewCancelFeedbackButton": "Voorvertoning annuleringsfeedback",
   "enableBatchCostingButton": "Enable batch costing",
+  "batchCostingSummarySaveButton": "Save quote",
+  "batchCostingSummarySaveSuccessTitle": "Quote saved",
+  "batchCostingSummarySaveSuccessBody": "Saved to history.",
+  "batchCostingSummaryViewHistoryButton": "View history",
+  "batchCostingSummarySaveErrorMessage": "Could not save quote",
+  "batchCostingSummaryDefaultQuoteName": "Batch quote",
+  "batchHistoryItemsTitle": "Batch items",
+  "batchHistorySummaryLine": "{itemCount} items • {totalQuantity} copies",
+  "@batchHistorySummaryLine": {
+    "placeholders": {
+      "itemCount": {},
+      "totalQuantity": {}
+    }
+  },
+  "batchHistoryItemRow": "{name} × {quantity}",
+  "@batchHistoryItemRow": {
+    "placeholders": {
+      "name": {},
+      "quantity": {}
+    }
+  },
   "showWhatsNewButton": "Show What's New",
   "enablePremiumTitle": "Premium inschakelen",
   "enablePremiumBody": "Voer de bevestigingscode in om lokale premiumtests in te schakelen",

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -336,6 +336,27 @@
   "clearUpdateCooldownButton": "Limpar espera de atualização",
   "previewCancelFeedbackButton": "Prévia do feedback de cancelamento",
   "enableBatchCostingButton": "Enable batch costing",
+  "batchCostingSummarySaveButton": "Save quote",
+  "batchCostingSummarySaveSuccessTitle": "Quote saved",
+  "batchCostingSummarySaveSuccessBody": "Saved to history.",
+  "batchCostingSummaryViewHistoryButton": "View history",
+  "batchCostingSummarySaveErrorMessage": "Could not save quote",
+  "batchCostingSummaryDefaultQuoteName": "Batch quote",
+  "batchHistoryItemsTitle": "Batch items",
+  "batchHistorySummaryLine": "{itemCount} items • {totalQuantity} copies",
+  "@batchHistorySummaryLine": {
+    "placeholders": {
+      "itemCount": {},
+      "totalQuantity": {}
+    }
+  },
+  "batchHistoryItemRow": "{name} × {quantity}",
+  "@batchHistoryItemRow": {
+    "placeholders": {
+      "name": {},
+      "quantity": {}
+    }
+  },
   "showWhatsNewButton": "Show What's New",
   "enablePremiumTitle": "Ativar premium",
   "enablePremiumBody": "Insira o código de confirmação para ativar os testes locais de premium",

--- a/lib/l10n/intl_th.arb
+++ b/lib/l10n/intl_th.arb
@@ -330,6 +330,27 @@
   "clearUpdateCooldownButton": "ล้างช่วงพักอัปเดต",
   "previewCancelFeedbackButton": "ดูตัวอย่างความคิดเห็นการยกเลิก",
   "enableBatchCostingButton": "Enable batch costing",
+  "batchCostingSummarySaveButton": "Save quote",
+  "batchCostingSummarySaveSuccessTitle": "Quote saved",
+  "batchCostingSummarySaveSuccessBody": "Saved to history.",
+  "batchCostingSummaryViewHistoryButton": "View history",
+  "batchCostingSummarySaveErrorMessage": "Could not save quote",
+  "batchCostingSummaryDefaultQuoteName": "Batch quote",
+  "batchHistoryItemsTitle": "Batch items",
+  "batchHistorySummaryLine": "{itemCount} items • {totalQuantity} copies",
+  "@batchHistorySummaryLine": {
+    "placeholders": {
+      "itemCount": {},
+      "totalQuantity": {}
+    }
+  },
+  "batchHistoryItemRow": "{name} × {quantity}",
+  "@batchHistoryItemRow": {
+    "placeholders": {
+      "name": {},
+      "quantity": {}
+    }
+  },
   "showWhatsNewButton": "Show What's New",
   "enablePremiumTitle": "เปิดใช้งานพรีเมียม",
   "enablePremiumBody": "ป้อนรหัสยืนยันเพื่อเปิดการทดสอบพรีเมียมภายในเครื่อง",

--- a/test/batch_costing/batch_summary_page_test.dart
+++ b/test/batch_costing/batch_summary_page_test.dart
@@ -64,6 +64,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('27.00'), findsOneWidget);
+    expect(find.text('Save quote'), findsOneWidget);
 
     await tester.tap(find.text('Benchy'));
     await tester.pumpAndSettle();

--- a/test/history/components/history_item_test.dart
+++ b/test/history/components/history_item_test.dart
@@ -175,6 +175,19 @@ void main() {
     );
   });
 
+  testWidgets('batch quote hides load action', (tester) async {
+    final model = _model().copyWith(batchQuote: true);
+    await tester.pumpApp(HistoryItem(dbKey: 'history-1', data: model));
+
+    await tester.tap(find.byIcon(Icons.more_horiz));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(lookupAppLocalizations(const Locale('en')).historyLoadAction),
+      findsNothing,
+    );
+  });
+
   testWidgets('overflow button keeps strong contrast and tap target', (
     tester,
   ) async {

--- a/test/history/model/history_model_test.dart
+++ b/test/history/model/history_model_test.dart
@@ -1,4 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:threed_print_cost_calculator/batch_costing/helpers/batch_summary_calculator.dart';
+import 'package:threed_print_cost_calculator/batch_costing/model/batch_costing_item.dart';
+import 'package:threed_print_cost_calculator/batch_costing/state/batch_costing_state.dart';
+import 'package:threed_print_cost_calculator/batch_costing/state/batch_pricing_state.dart';
 import 'package:threed_print_cost_calculator/history/model/history_model.dart';
 
 void main() {
@@ -25,5 +29,41 @@ void main() {
     expect(model.labourCost, 1.25);
     expect(model.weight, 42.5);
     expect(model.importedFromGcode, isTrue);
+  });
+
+  test('HistoryModel.batchQuote round-trips batch snapshot fields', () {
+    final state = BatchCostingState(
+      items: [
+        BatchCostingItem.manual(
+          id: 'item-1',
+          displayName: 'Benchy',
+          quantity: 2,
+          printWeightG: 10,
+          printDuration: const Duration(hours: 1),
+          printerId: 'printer-1',
+          materialId: 'material-1',
+        ),
+      ],
+      batchPrinterId: 'printer-1',
+      batchMaterialId: 'material-1',
+      pricing: const BatchPricingState(
+        labourRate: BatchPricingFieldState(value: '10'),
+      ),
+    );
+    final summary = BatchSummaryCalculator.calculate(state);
+
+    final model = HistoryModel.batchQuote(
+      name: 'Batch quote',
+      date: DateTime.utc(2024, 1, 1),
+      state: state,
+      summary: summary,
+    );
+
+    final roundTrip = HistoryModel.fromMap(model.toMap());
+
+    expect(roundTrip.batchQuote, isTrue);
+    expect(roundTrip.batchQuoteItems, hasLength(1));
+    expect(roundTrip.batchQuoteSummary?['batchPrinterId'], 'printer-1');
+    expect(roundTrip.totalCost, summary.finalTotal);
   });
 }


### PR DESCRIPTION
## Summary
- Add save-to-history flow for completed batch quotes from batch summary.
- Persist batch snapshots in history without changing single-print history behavior.
- Add batch-specific history rendering and localized save/confirmation strings.

## Validation
- fvm flutter analyze
- make flutter_test
- fvm flutter test test/history/model/history_model_test.dart test/history/components/history_item_test.dart test/batch_costing/batch_summary_page_test.dart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now save batch quotes from the summary page and retrieve them from history
  * Saved quotes display with complete details including pricing breakdown, per-item costs, weights, and durations
  * Full multi-language support added for the batch quote save and history features

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RemeJuan/threed_print_cost_calculator/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->